### PR TITLE
[GUI] Transaction record cold staking fixes.

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -411,7 +411,8 @@ void TransactionRecord::loadHotOrColdStakeOrContract(
         if (isSpendable) {
             // Offline wallet receiving an stake due a delegation
             record.type = TransactionRecord::StakeDelegated;
-
+            record.credit = wtx.GetCredit(ISMINE_SPENDABLE_DELEGATED);
+            record.debit = -(wtx.GetDebit(ISMINE_SPENDABLE_DELEGATED));
         } else {
             // Online wallet receiving an stake due a received utxo delegation that won a block.
             record.type = TransactionRecord::StakeHot;
@@ -493,7 +494,13 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
         }
     }
     // For generated transactions, determine maturity
-    else if (type == TransactionRecord::Generated || type == TransactionRecord::StakeMint || type == TransactionRecord::StakeZEPG || type == TransactionRecord::MNReward) {
+    else if (type == TransactionRecord::Generated ||
+            type == TransactionRecord::StakeMint ||
+            type == TransactionRecord::StakeZPIV ||
+            type == TransactionRecord::MNReward ||
+            type == TransactionRecord::StakeDelegated ||
+            type == TransactionRecord::StakeHot) {
+        
         if (nBlocksToMaturity > 0) {
             status.status = TransactionStatus::Immature;
             status.matures_in = nBlocksToMaturity;


### PR DESCRIPTION
 [GUI] Transaction record cold staking fixes. # 1279

1) Cold stakes status was not set properly, there was no immaturity or "xxx blocks to mature" calculated.

2) GetCredit method in P2CS in wallets with both private keys is returning the real credit amount doubled because of be summing the cold staking credit and the delegated credit of the exact same utxo.

   Quick fix to solve it, only request one of them.. not the final solution.