### PR TITLE
Csv export

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -91,6 +91,7 @@ QT_FORMS_UI = \
   qt/epgc/forms/privacywidget.ui \
   qt/epgc/forms/coldstakingwidget.ui \
   qt/epgc/settings/forms/settingsbackupwallet.ui \
+  qt/epgc/settings/forms/settingsexportcsv.ui \
   qt/epgc/settings/forms/settingsbittoolwidget.ui \
   qt/epgc/settings/forms/settingsconsolewidget.ui \
   qt/epgc/settings/forms/settingsdisplayoptionswidget.ui \
@@ -188,6 +189,7 @@ QT_MOC_CPP = \
   qt/epgc/moc_privacywidget.cpp \
   qt/epgc/moc_coldstakingwidget.cpp \
   qt/epgc/settings/moc_settingsbackupwallet.cpp \
+  qt/epgc/settings/moc_settingsexportcsv.cpp \
   qt/epgc/settings/moc_settingsbittoolwidget.cpp \
   qt/epgc/settings/moc_settingsconsolewidget.cpp \
   qt/epgc/settings/moc_settingsdisplayoptionswidget.cpp \
@@ -319,6 +321,7 @@ BITCOIN_QT_H = \
   qt/epgc/privacywidget.h \
   qt/epgc/coldstakingwidget.h \
   qt/epgc/settings/settingsbackupwallet.h \
+  qt/epgc/settings/settingsexportcsv.h \
   qt/epgc/settings/settingsbittoolwidget.h \
   qt/epgc/settings/settingsconsolewidget.h \
   qt/epgc/settings/settingsdisplayoptionswidget.h \
@@ -707,6 +710,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/epgc/privacywidget.cpp \
   qt/epgc/coldstakingwidget.cpp \
   qt/epgc/settings/settingsbackupwallet.cpp \
+  qt/epgc/settings/settingsexportcsv.cpp \
   qt/epgc/settings/settingsbittoolwidget.cpp \
   qt/epgc/settings/settingsconsolewidget.cpp \
   qt/epgc/settings/settingsdisplayoptionswidget.cpp \

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -155,6 +155,7 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/privacywidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/coldstakingwidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/settings/settingsbackupwallet.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/epgc/settings/settingsexportcsv.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/settings/settingsbittoolwidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/settings/settingsconsolewidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/epgc/settings/settingsdisplayoptionswidget.cpp

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -22,7 +22,7 @@ const QString AddressTableModel::Receive = "R";
 const QString AddressTableModel::Zerocoin = "X";
 const QString AddressTableModel::Delegators = "D";
 const QString AddressTableModel::ColdStaking = "C";
-const QString AddressTableModel::ColdStakingSend = "Csend";
+const QString AddressTableModel::ColdStakingSend = "T";
 
 struct AddressTableEntry {
     enum Type {
@@ -81,6 +81,27 @@ static AddressTableEntry::Type translateTransactionType(const QString& strPurpos
         addressType = (isMine ? AddressTableEntry::Receiving : AddressTableEntry::Sending);
     return addressType;
 }
+
+static QString translateTypeToString(AddressTableEntry::Type type)
+{
+    switch (type) {
+        case AddressTableEntry::Sending:
+            return QObject::tr("Contact");
+        case AddressTableEntry::Receiving:
+            return QObject::tr("Receiving");
+        case AddressTableEntry::Delegators:
+            return QObject::tr("Delegator");
+        case AddressTableEntry::ColdStaking:
+            return QObject::tr("Cold Staking");
+        case AddressTableEntry::ColdStakingSend:
+            return QObject::tr("Cold Staking Contact");
+        case AddressTableEntry::Hidden:
+            return QObject::tr("Hidden");
+        default:
+            return QObject::tr("Unknown");
+    }
+}
+
 
 // Private implementation
 class AddressTablePriv
@@ -276,7 +297,7 @@ public:
 
 AddressTableModel::AddressTableModel(CWallet* wallet, WalletModel* parent) : QAbstractTableModel(parent), walletModel(parent), wallet(wallet), priv(0)
 {
-    columns << tr("Label") << tr("Address") << tr("Date");
+    columns << tr("Label") << tr("Address") << tr("Date") << tr("Type");
     priv = new AddressTablePriv(wallet, this);
     priv->refreshAddressTable();
 }
@@ -332,6 +353,8 @@ QVariant AddressTableModel::data(const QModelIndex& index, int role) const
             return rec->address;
         case Date:
             return rec->creationTime;
+        case Type:
+            return translateTypeToString(rec->type);
         }
     } else if (role == Qt::FontRole) {
         QFont font;

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -28,11 +28,12 @@ public:
     enum ColumnIndex {
         Label = 0,  /**< User specified label */
         Address = 1, /**< Bitcoin address */
-        Date = 2 /**< Address creation date */
+        Date = 2, /**< Address creation date */
+        Type = 3 /**< Address Type */
     };
 
     enum RoleIndex {
-        TypeRole = Qt::UserRole /**< Type of address (#Send or #Receive) */
+        TypeRole = Qt::UserRole /**< Type of address (#Send, #Receive, #ColdStaking, #ColdStakingSend, #Delegators) */
     };
 
     /** Return status of edit/insert operation */

--- a/src/qt/epgc/dashboardwidget.cpp
+++ b/src/qt/epgc/dashboardwidget.cpp
@@ -89,31 +89,14 @@ DashboardWidget::DashboardWidget(EPGCGUI* parent) :
 
     // Sort Transactions
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
-    initComboBox(ui->comboBoxSort, lineEdit);
     connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
-    ui->comboBoxSort->addItem("Date desc", SortTx::DATE_DESC);
-    ui->comboBoxSort->addItem("Date asc", SortTx::DATE_ASC);
-    ui->comboBoxSort->addItem("Amount desc", SortTx::AMOUNT_ASC);
-    ui->comboBoxSort->addItem("Amount asc", SortTx::AMOUNT_DESC);
+    setSortTx(ui->comboBoxSort, lineEdit);
     connect(ui->comboBoxSort, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(onSortChanged(const QString&)));
 
     // Sort type
     SortEdit* lineEditType = new SortEdit(ui->comboBoxSortType);
-    initComboBox(ui->comboBoxSortType, lineEditType);
     connect(lineEditType, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortType->showPopup();});
-
-    QSettings settings;
-    ui->comboBoxSortType->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
-    ui->comboBoxSortType->addItem(tr("Received"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) | TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
-    ui->comboBoxSortType->addItem(tr("Sent"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) | TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
-    ui->comboBoxSortType->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    ui->comboBoxSortType->addItem(tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
-    ui->comboBoxSortType->addItem(tr("MN reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
-    ui->comboBoxSortType->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
-    ui->comboBoxSortType->addItem(tr("Cold stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeDelegated));
-    ui->comboBoxSortType->addItem(tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
-    ui->comboBoxSortType->addItem(tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
-    ui->comboBoxSortType->addItem(tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
+    setSortTxTypeFilter(ui->comboBoxSortType, lineEditType);
     ui->comboBoxSortType->setCurrentIndex(0);
     connect(ui->comboBoxSortType, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(onSortTypeChanged(const QString&)));
 

--- a/src/qt/epgc/qtutils.cpp
+++ b/src/qt/epgc/qtutils.cpp
@@ -122,6 +122,40 @@ QPixmap encodeToQr(QString str, QString &errorStr, QColor qrColor){
     return QPixmap();
 }
 
+void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit) {
+    initComboBox(filter, lineEdit);
+    filter->addItem("All", "");
+    filter->addItem("Receiving", AddressTableModel::Receive);
+    filter->addItem("Contacts", AddressTableModel::Send);
+    filter->addItem("Cold Staking", AddressTableModel::ColdStaking);
+    filter->addItem("Delegators", AddressTableModel::Delegators);
+    filter->addItem("Staking Contacts", AddressTableModel::ColdStakingSend);
+}
+
+void setSortTx(QComboBox* filter, SortEdit* lineEdit) {
+    // Sort Transactions
+    initComboBox(filter, lineEdit);
+    filter->addItem("Date desc", SortTx::DATE_DESC);
+    filter->addItem("Date asc", SortTx::DATE_ASC);
+    filter->addItem("Amount desc", SortTx::AMOUNT_ASC);
+    filter->addItem("Amount asc", SortTx::AMOUNT_DESC);
+}
+
+void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType) {
+    initComboBox(filter, lineEditType);
+    filter->addItem(filter->tr("All"), TransactionFilterProxy::ALL_TYPES);
+    filter->addItem(filter->tr("Received"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) | TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
+    filter->addItem(filter->tr("Sent"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) | TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
+    filter->addItem(filter->tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    filter->addItem(filter->tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
+    filter->addItem(filter->tr("MN reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
+    filter->addItem(filter->tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
+    filter->addItem(filter->tr("Cold stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeDelegated));
+    filter->addItem(filter->tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
+    filter->addItem(filter->tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
+    filter->addItem(filter->tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
+}
+
 void setupSettings(QSettings *settings){
     if(!settings->contains("lightTheme")){
         settings->setValue("lightTheme", true);

--- a/src/qt/epgc/qtutils.h
+++ b/src/qt/epgc/qtutils.h
@@ -44,6 +44,11 @@ QPixmap encodeToQr(QString str, QString &errorStr, QColor qrColor = Qt::black);
 void updateStyle(QWidget* widget);
 QColor getRowColor(bool isLightTheme, bool isHovered, bool isSelected);
 
+// filters
+void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit);
+void setSortTx(QComboBox* filter, SortEdit* lineEdit);
+void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEdit);
+
 // Settings
 QSettings* getSettings();
 void setupSettings(QSettings *settings);

--- a/src/qt/epgc/settings/forms/settingsbackupwallet.ui
+++ b/src/qt/epgc/settings/forms/settingsbackupwallet.ui
@@ -118,64 +118,6 @@
        </layout>
       </item>
       <item>
-       <spacer name="verticalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonSave">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>200</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
        <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -206,19 +148,6 @@
          <string/>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayoutTitle_2">

--- a/src/qt/epgc/settings/forms/settingsexportcsv.ui
+++ b/src/qt/epgc/settings/forms/settingsexportcsv.ui
@@ -175,64 +175,6 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonSave">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>220</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
-          </property>
-          <property name="text">
-           <string>Export Transactions</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>5</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <widget class="QLabel" name="labelDivider">
         <property name="minimumSize">
          <size>
@@ -252,29 +194,13 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Minimum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>5</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <layout class="QVBoxLayout" name="verticalLayoutAddressesExport">
         <property name="spacing">
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="filtersContainer" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout">
+         <widget class="QWidget" name="filtersContainer1" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout1">
            <property name="spacing">
             <number>0</number>
            </property>
@@ -298,7 +224,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer">
+            <spacer name="horizontalSpacer1">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
@@ -342,64 +268,6 @@
           </property>
           <property name="text">
            <string>Select folder...</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_6">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonExportAddress">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>220</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
-          </property>
-          <property name="text">
-           <string>Export Address Book</string>
           </property>
          </widget>
         </item>

--- a/src/qt/epgc/settings/forms/settingswidget.ui
+++ b/src/qt/epgc/settings/forms/settingswidget.ui
@@ -56,37 +56,51 @@
          <number>0</number>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_1">
-          <property name="spacing">
-           <number>0</number>
+         <widget class="QWidget" name="titleMenuList" native="true">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>30</height>
+           </size>
           </property>
-          <property name="leftMargin">
-           <number>20</number>
-          </property>
-          <property name="rightMargin">
-           <number>20</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="labelTitle">
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+          <layout class="QHBoxLayout" name="horizontalLayout_1">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>20</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>20</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="labelTitle">
+             <property name="text">
+              <string>Settings</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
          <spacer name="verticalSpacer_2">
@@ -109,7 +123,7 @@
           <item>
            <widget class="QScrollArea" name="scrollArea">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -133,16 +147,22 @@
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>-490</y>
+               <y>-68</y>
                <width>230</width>
-               <height>887</height>
+               <height>452</height>
               </rect>
              </property>
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>650</height>
+              </size>
              </property>
              <property name="autoFillBackground">
               <bool>true</bool>
@@ -168,13 +188,22 @@
               </property>
               <item>
                <layout class="QVBoxLayout" name="verticalLayout_4">
-                <item>
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item alignment="Qt::AlignTop">
                  <widget class="QGroupBox" name="groupBox">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>450</height>
+                   </size>
                   </property>
                   <property name="title">
                    <string/>
@@ -196,48 +225,68 @@
                     <number>0</number>
                    </property>
                    <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_2">
-                     <property name="spacing">
-                      <number>0</number>
+                    <widget class="QWidget" name="menuFileContainer" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>160</height>
+                      </size>
                      </property>
-                     <property name="leftMargin">
-                      <number>20</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>20</number>
-                     </property>
-                     <item alignment="Qt::AlignTop">
-                      <widget class="QPushButton" name="pushButtonFile">
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>50</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>16777215</width>
-                         <height>50</height>
-                        </size>
-                       </property>
-                       <property name="focusPolicy">
-                        <enum>Qt::NoFocus</enum>
-                       </property>
-                       <property name="text">
-                        <string>Wallet Data</string>
-                       </property>
-                       <property name="checkable">
-                        <bool>true</bool>
-                       </property>
-                       <property name="autoExclusive">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
+                     <layout class="QHBoxLayout" name="horizontalLayout_2">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>20</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>20</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item alignment="Qt::AlignTop">
+                       <widget class="QPushButton" name="pushButtonFile">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
+                        <property name="text">
+                         <string>Wallet Data</string>
+                        </property>
+                        <property name="checkable">
+                         <bool>true</bool>
+                        </property>
+                        <property name="autoExclusive">
+                         <bool>false</bool>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
                    </item>
                    <item>
                     <widget class="QWidget" name="fileButtonsWidget" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>165</height>
+                      </size>
+                     </property>
                      <layout class="QVBoxLayout" name="verticalLayout_6">
                       <property name="spacing">
                        <number>0</number>
@@ -310,52 +359,100 @@
                         </property>
                        </widget>
                       </item>
+                      <item>
+                       <widget class="QPushButton" name="pushButtonExportCsv">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
+                        <property name="text">
+                         <string>Export Accounting</string>
+                        </property>
+                        <property name="checkable">
+                         <bool>true</bool>
+                        </property>
+                        <property name="autoExclusive">
+                         <bool>false</bool>
+                        </property>
+                       </widget>
+                      </item>
                      </layout>
                     </widget>
                    </item>
                    <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_3">
-                     <property name="spacing">
-                      <number>0</number>
+                    <widget class="QWidget" name="menuToolsContainer" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>160</height>
+                      </size>
                      </property>
-                     <property name="leftMargin">
-                      <number>20</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>20</number>
-                     </property>
-                     <item alignment="Qt::AlignTop">
-                      <widget class="QPushButton" name="pushButtonConfiguration">
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>50</height>
-                        </size>
-                       </property>
-                       <property name="maximumSize">
-                        <size>
-                         <width>16777215</width>
-                         <height>50</height>
-                        </size>
-                       </property>
-                       <property name="focusPolicy">
-                        <enum>Qt::NoFocus</enum>
-                       </property>
-                       <property name="text">
-                        <string>Tools</string>
-                       </property>
-                       <property name="checkable">
-                        <bool>true</bool>
-                       </property>
-                       <property name="autoExclusive">
-                        <bool>false</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
+                     <layout class="QHBoxLayout" name="horizontalLayout_3">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>20</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>20</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item alignment="Qt::AlignTop">
+                       <widget class="QPushButton" name="pushButtonConfiguration">
+                        <property name="minimumSize">
+                         <size>
+                          <width>0</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="maximumSize">
+                         <size>
+                          <width>16777215</width>
+                          <height>50</height>
+                         </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
+                        <property name="text">
+                         <string>Tools</string>
+                        </property>
+                        <property name="checkable">
+                         <bool>true</bool>
+                        </property>
+                        <property name="autoExclusive">
+                         <bool>false</bool>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
                    </item>
                    <item>
                     <widget class="QWidget" name="configurationButtonsWidget" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>105</height>
+                      </size>
+                     </property>
                      <layout class="QVBoxLayout" name="verticalLayout_7">
                       <property name="spacing">
                        <number>0</number>
@@ -474,6 +571,12 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="optionsButtonsWidget" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>160</height>
+                      </size>
+                     </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">
                       <property name="spacing">
                        <number>0</number>
@@ -623,6 +726,12 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="toolsButtonsWidget" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>160</height>
+                      </size>
+                     </property>
                      <layout class="QVBoxLayout" name="verticalTools_11">
                       <property name="spacing">
                        <number>0</number>
@@ -772,6 +881,12 @@
                    </item>
                    <item>
                     <widget class="QWidget" name="helpButtonsWidget" native="true">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>100</height>
+                      </size>
+                     </property>
                      <layout class="QVBoxLayout" name="verticalHelp">
                       <property name="spacing">
                        <number>0</number>

--- a/src/qt/epgc/settings/settingsbackupwallet.cpp
+++ b/src/qt/epgc/settings/settingsbackupwallet.cpp
@@ -46,36 +46,24 @@ SettingsBackupWallet::SettingsBackupWallet(EPGCGUI* _window, QWidget *parent) :
     setShadow(ui->pushButtonDocuments);
 
     // Buttons
-    ui->pushButtonSave->setText(tr("Backup"));
-    setCssBtnPrimary(ui->pushButtonSave);
-
     ui->pushButtonSave_2->setText(tr("Change Passphrase"));
     setCssBtnPrimary(ui->pushButtonSave_2);
 
-    connect(ui->pushButtonSave, SIGNAL(clicked()), this, SLOT(backupWallet()));
-    connect(ui->pushButtonDocuments, SIGNAL(clicked()), this, SLOT(selectFileOutput()));
-    connect(ui->pushButtonSave_2, SIGNAL(clicked()), this, SLOT(changePassphrase()));
+    connect(ui->pushButtonDocuments, &QPushButton::clicked, this, &SettingsBackupWallet::selectFileOutput);
+    connect(ui->pushButtonSave_2, &QPushButton::clicked, this, &SettingsBackupWallet::changePassphrase);
 }
 
 void SettingsBackupWallet::selectFileOutput()
 {
-    QString filenameRet = GUIUtil::getSaveFileName(this,
+    QString filename = GUIUtil::getSaveFileName(this,
                                         tr("Backup Wallet"), QString(),
                                         tr("Wallet Data (*.dat)"), NULL);
 
-    if (!filenameRet.isEmpty()) {
-        filename = filenameRet;
+    if (!filename.isEmpty() && walletModel) {
         ui->pushButtonDocuments->setText(filename);
-    }
-}
-
-void SettingsBackupWallet::backupWallet()
-{
-    if(walletModel && !filename.isEmpty()) {
         inform(walletModel->backupWallet(filename) ? tr("Backup created") : tr("Backup creation failed"));
-        filename = QString();
-        ui->pushButtonDocuments->setText(tr("Select folder..."));
     } else {
+        ui->pushButtonDocuments->setText(tr("Select folder..."));
         inform(tr("Please select a folder to export the backup first."));
     }
 }
@@ -92,7 +80,7 @@ void SettingsBackupWallet::changePassphrase()
                 walletModel, AskPassphraseDialog::Context::ChangePass);
     }
     dlg->adjustSize();
-    emit execDialog(dlg);
+    Q_EMIT execDialog(dlg);
     dlg->deleteLater();
 }
 

--- a/src/qt/epgc/settings/settingsbackupwallet.h
+++ b/src/qt/epgc/settings/settingsbackupwallet.h
@@ -20,14 +20,12 @@ public:
     explicit SettingsBackupWallet(EPGCGUI* _window, QWidget *parent = nullptr);
     ~SettingsBackupWallet();
 
-private slots:
-    void backupWallet();
+private Q_SLOTS:
     void selectFileOutput();
     void changePassphrase();
 
 private:
     Ui::SettingsBackupWallet *ui;
-    QString filename;
 };
 
 #endif // SETTINGSBACKUPWALLET_H

--- a/src/qt/epgc/settings/settingsexportcsv.cpp
+++ b/src/qt/epgc/settings/settingsexportcsv.cpp
@@ -2,16 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "qt/pivx/settings/settingsexportcsv.h"
-#include "qt/pivx/settings/forms/ui_settingsexportcsv.h"
+#include "qt/epgc/settings/settingsexportcsv.h"
+#include "qt/epgc/settings/forms/ui_settingsexportcsv.h"
 #include <QFile>
 #include "csvmodelwriter.h"
 #include "guiutil.h"
 #include "optionsmodel.h"
-#include "qt/pivx/qtutils.h"
+#include "qt/epgc/qtutils.h"
 #include "guiinterface.h"
 
-SettingsExportCSV::SettingsExportCSV(PIVXGUI* _window, QWidget *parent) :
+SettingsExportCSV::SettingsExportCSV(EPGCGUI* _window, QWidget *parent) :
     PWidget(_window, parent),
     ui(new Ui::SettingsExportCSV)
 {
@@ -37,10 +37,6 @@ SettingsExportCSV::SettingsExportCSV(PIVXGUI* _window, QWidget *parent) :
     setShadow(ui->pushButtonAddressDocuments);
     ui->labelDivider->setProperty("cssClass", "container-divider");
 
-    // Buttons
-    setCssBtnPrimary(ui->pushButtonSave);
-    setCssBtnPrimary(ui->pushButtonExportAddress);
-
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
     connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
     setSortTx(ui->comboBoxSort, lineEdit);
@@ -55,32 +51,35 @@ SettingsExportCSV::SettingsExportCSV(PIVXGUI* _window, QWidget *parent) :
     setFilterAddressBook(ui->comboBoxSortAddressType, lineEditAddressBook);
     ui->comboBoxSortAddressType->setCurrentIndex(0);
 
-    connect(ui->pushButtonSave, SIGNAL(clicked()), this, SLOT(exportClicked()));
     connect(ui->pushButtonDocuments, &QPushButton::clicked, [this](){selectFileOutput(true);});
-
-    connect(ui->pushButtonExportAddress, SIGNAL(clicked()), this, SLOT(onExportAddressesClicked()));
     connect(ui->pushButtonAddressDocuments, &QPushButton::clicked, [this](){selectFileOutput(false);});
 }
 
 void SettingsExportCSV::selectFileOutput(const bool& isTxExport)
 {
-    QString filenameRet = GUIUtil::getSaveFileName(this,
+    QString filename = GUIUtil::getSaveFileName(this,
                                         isTxExport ? tr("Export CSV") : tr("Export Address List"), QString(),
-                                        isTxExport ? tr("PIVX_tx_csv_export(*.csv)") : tr("PIVX_addresses_csv_export(*.csv)"),
+                                        isTxExport ? tr("EPGC_tx_csv_export(*.csv)") : tr("EPGC_addresses_csv_export(*.csv)"),
                                         nullptr);
 
-    if (!filenameRet.isEmpty()) {
-        if (isTxExport) {
-            filename = filenameRet;
+    if (isTxExport) {
+        if (!filename.isEmpty()) {
             ui->pushButtonDocuments->setText(filename);
+            exportTxes(filename);
         } else {
-            filenameAddressBook = filenameRet;
-            ui->pushButtonAddressDocuments->setText(filenameAddressBook);
+            ui->pushButtonDocuments->setText(tr("Select folder..."));
+        }
+    } else {
+        if (!filename.isEmpty()) {
+            ui->pushButtonAddressDocuments->setText(filename);
+            exportAddrs(filename);
+        } else {
+            ui->pushButtonAddressDocuments->setText(tr("Select folder..."));
         }
     }
 }
 
-void SettingsExportCSV::exportClicked()
+void SettingsExportCSV::exportTxes(const QString& filename)
 {
     if (filename.isNull()) {
         inform(tr("Please select a folder to export the csv file first."));
@@ -152,9 +151,9 @@ void SettingsExportCSV::exportClicked()
     }
 }
 
-void SettingsExportCSV::onExportAddressesClicked()
+void SettingsExportCSV::exportAddrs(const QString& filename)
 {
-    if (filenameAddressBook.isNull()) {
+    if (filename.isNull()) {
         inform(tr("Please select a folder to export the csv file first."));
         return;
     }
@@ -178,7 +177,7 @@ void SettingsExportCSV::onExportAddressesClicked()
             return;
         }
 
-        CSVModelWriter writer(filenameAddressBook);
+        CSVModelWriter writer(filename);
         // name, column, role
         writer.setModel(addressFilter);
         writer.addColumn("Label", AddressTableModel::Label, Qt::EditRole);
@@ -188,9 +187,9 @@ void SettingsExportCSV::onExportAddressesClicked()
     }
 
     if (fExport) {
-        inform(tr("Exporting Successful\nThe address book was successfully saved to %1.").arg(filenameAddressBook));
+        inform(tr("Exporting Successful\nThe address book was successfully saved to %1.").arg(filename));
     } else {
-        inform(tr("Exporting Failed\nThere was an error trying to save the address list to %1. Please try again.").arg(filenameAddressBook));
+        inform(tr("Exporting Failed\nThere was an error trying to save the address list to %1. Please try again.").arg(filename));
     }
 }
 

--- a/src/qt/epgc/settings/settingsexportcsv.h
+++ b/src/qt/epgc/settings/settingsexportcsv.h
@@ -6,7 +6,7 @@
 #define SETTINGSEXPORTCSV_H
 
 #include <QWidget>
-#include "qt/pivx/pwidget.h"
+#include "qt/epgc/pwidget.h"
 #include "transactionfilterproxy.h"
 #include <QSortFilterProxyModel>
 
@@ -19,20 +19,18 @@ class SettingsExportCSV : public PWidget
     Q_OBJECT
 
 public:
-    explicit SettingsExportCSV(PIVXGUI* _window, QWidget *parent = nullptr);
+    explicit SettingsExportCSV(EPGCGUI* _window, QWidget *parent = nullptr);
     ~SettingsExportCSV();
 
 private Q_SLOTS:
     void selectFileOutput(const bool& isTxExport);
-    void exportClicked();
-    void onExportAddressesClicked();
+    void exportTxes(const QString& filename);
+    void exportAddrs(const QString& filename);
 
 private:
     Ui::SettingsExportCSV *ui;
     TransactionFilterProxy* txFilter{nullptr};
     QSortFilterProxyModel* addressFilter{nullptr};
-    QString filename;
-    QString filenameAddressBook;
 };
 
 #endif // SETTINGSEXPORTCSV_H

--- a/src/qt/epgc/settings/settingswidget.cpp
+++ b/src/qt/epgc/settings/settingswidget.cpp
@@ -44,13 +44,13 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     fontLight.setWeight(QFont::Light);
 
     /* Title */
-    ui->labelTitle->setText(tr("Settings"));
     setCssProperty(ui->labelTitle, "text-title-screen");
     ui->labelTitle->setFont(fontLight);
 
     setCssProperty(ui->pushButtonFile, "btn-settings-check");
     setCssProperty(ui->pushButtonFile2, "btn-settings-options");
     setCssProperty(ui->pushButtonFile3, "btn-settings-options");
+    setCssProperty(ui->pushButtonExportCsv, "btn-settings-options");
 
     setCssProperty(ui->pushButtonConfiguration, "btn-settings-check");
     setCssProperty(ui->pushButtonConfiguration3, "btn-settings-options");
@@ -73,6 +73,7 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     options = {
         ui->pushButtonFile2,
         ui->pushButtonFile3,
+        ui->pushButtonExportCsv,
         ui->pushButtonOptions1,
         ui->pushButtonOptions2,
         ui->pushButtonOptions5,
@@ -84,16 +85,14 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
         ui->pushButtonTools5,
     };
 
-    ui->pushButtonFile->setChecked(true);
-    ui->fileButtonsWidget->setVisible(true);
-    ui->optionsButtonsWidget->setVisible(false);
-    ui->configurationButtonsWidget->setVisible(false);
-    ui->toolsButtonsWidget->setVisible(false);
-    ui->helpButtonsWidget->setVisible(false);
-
-    ui->pushButtonFile2->setChecked(true);
+    menus.insert(ui->pushButtonFile, ui->fileButtonsWidget);
+    menus.insert(ui->pushButtonConfiguration, ui->configurationButtonsWidget);
+    menus.insert(ui->pushButtonOptions, ui->optionsButtonsWidget);
+    menus.insert(ui->pushButtonTools, ui->toolsButtonsWidget);
+    menus.insert(ui->pushButtonHelp, ui->helpButtonsWidget);
 
     settingsBackupWallet = new SettingsBackupWallet(window, this);
+    settingsExportCsvWidget = new SettingsExportCSV(window, this);
     settingsBitToolWidget = new SettingsBitToolWidget(window, this);
     settingsSingMessageWidgets = new SettingsSignMessageWidgets(window, this);
     settingsWalletRepairWidget = new SettingsWalletRepairWidget(window, this);
@@ -105,6 +104,7 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     settingsConsoleWidget = new SettingsConsoleWidget(window, this);
 
     ui->stackedWidgetContainer->addWidget(settingsBackupWallet);
+    ui->stackedWidgetContainer->addWidget(settingsExportCsvWidget);
     ui->stackedWidgetContainer->addWidget(settingsBitToolWidget);
     ui->stackedWidgetContainer->addWidget(settingsSingMessageWidgets);
     ui->stackedWidgetContainer->addWidget(settingsWalletRepairWidget);
@@ -120,6 +120,7 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     connect(ui->pushButtonFile, SIGNAL(clicked()), this, SLOT(onFileClicked()));
     connect(ui->pushButtonFile2, SIGNAL(clicked()), this, SLOT(onBackupWalletClicked()));
     connect(ui->pushButtonFile3, SIGNAL(clicked()), this, SLOT(onMultisendClicked()));
+    connect(ui->pushButtonExportCsv, SIGNAL(clicked()), this, SLOT(onExportCSVClicked()));
 
     // Options
     connect(ui->pushButtonOptions, SIGNAL(clicked()), this, SLOT(onOptionsClicked()));
@@ -147,9 +148,12 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     // Get restart command-line parameters and handle restart
     connect(settingsWalletRepairWidget, &SettingsWalletRepairWidget::handleRestart, [this](QStringList arg){emit handleRestart(arg);});
 
-    connect(settingsBackupWallet,&SettingsBackupWallet::message,this, &SettingsWidget::message);
+    connect(settingsBackupWallet, &SettingsBackupWallet::message,this, &SettingsWidget::message);
     connect(settingsBackupWallet, &SettingsBackupWallet::showHide, this, &SettingsWidget::showHide);
     connect(settingsBackupWallet, &SettingsBackupWallet::execDialog, this, &SettingsWidget::execDialog);
+    connect(settingsExportCsvWidget, &SettingsExportCSV::message,this, &SettingsWidget::message);
+    connect(settingsExportCsvWidget, &SettingsExportCSV::showHide, this, &SettingsWidget::showHide);
+    connect(settingsExportCsvWidget, &SettingsExportCSV::execDialog, this, &SettingsWidget::execDialog);
     connect(settingsMultisendWidget, &SettingsMultisendWidget::showHide, this, &SettingsWidget::showHide);
     connect(settingsMultisendWidget, &SettingsMultisendWidget::message, this, &SettingsWidget::message);
     connect(settingsMainOptionsWidget, &SettingsMainOptionsWidget::message, this, &SettingsWidget::message);
@@ -161,9 +165,23 @@ SettingsWidget::SettingsWidget(EPGCGUI* parent) :
     mapper = new QDataWidgetMapper(this);
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
     mapper->setOrientation(Qt::Vertical);
+
+    // scroll area
+    ui->scrollArea->setWidgetResizable(true);
+    QSizePolicy scrollAreaPolicy = ui->scrollArea->sizePolicy();
+    scrollAreaPolicy.setVerticalStretch(1);
+    ui->scrollArea->setSizePolicy(scrollAreaPolicy);
+    QSizePolicy scrollVertPolicy = ui->scrollAreaWidgetContents->sizePolicy();
+    scrollVertPolicy.setVerticalStretch(1);
+    ui->scrollAreaWidgetContents->setSizePolicy(scrollVertPolicy);
+
+    ui->pushButtonFile->setChecked(true);
+    onFileClicked();
+    ui->pushButtonFile2->setChecked(true);
 }
 
-void SettingsWidget::loadClientModel(){
+void SettingsWidget::loadClientModel()
+{
     if(clientModel) {
         this->settingsInformationWidget->setClientModel(this->clientModel);
         this->settingsConsoleWidget->setClientModel(this->clientModel);
@@ -186,6 +204,7 @@ void SettingsWidget::loadClientModel(){
 
 void SettingsWidget::loadWalletModel(){
     this->settingsBackupWallet->setWalletModel(this->walletModel);
+    this->settingsExportCsvWidget->setWalletModel(this->walletModel);
     this->settingsSingMessageWidgets->setWalletModel(this->walletModel);
     this->settingsBitToolWidget->setWalletModel(this->walletModel);
     this->settingsMultisendWidget->setWalletModel(this->walletModel);
@@ -235,23 +254,28 @@ void SettingsWidget::onSaveOptionsClicked(){
     }
 }
 
-void SettingsWidget::onFileClicked() {
-    if (ui->pushButtonFile->isChecked()) {
-        ui->fileButtonsWidget->setVisible(true);
-
-        ui->optionsButtonsWidget->setVisible(false);
-        ui->toolsButtonsWidget->setVisible(false);
-        ui->configurationButtonsWidget->setVisible(false);
-        ui->helpButtonsWidget->setVisible(false);
-        ui->pushButtonOptions->setChecked(false);
-        ui->pushButtonTools->setChecked(false);
-        ui->pushButtonConfiguration->setChecked(false);
-        ui->pushButtonHelp->setChecked(false);
-
+void SettingsWidget::selectMenu(QPushButton* btn)
+{
+    QWidget* subMenuSelected = menus[btn];
+    if (btn->isChecked()) {
+        QMapIterator<QPushButton*, QWidget*> it(menus);
+        while (it.hasNext()) {
+            it.next();
+            QWidget* value = it.value();
+            QPushButton* key = it.key();
+            value->setVisible(value == subMenuSelected);
+            if (key != btn) key->setChecked(false);
+        }
     } else {
-        ui->fileButtonsWidget->setVisible(false);
+        subMenuSelected->setVisible(false);
     }
 }
+
+void SettingsWidget::onFileClicked()
+{
+    selectMenu(ui->pushButtonFile);
+}
+
 
 void SettingsWidget::onBackupWalletClicked() {
     ui->stackedWidgetContainer->setCurrentWidget(settingsBackupWallet);
@@ -264,21 +288,7 @@ void SettingsWidget::onSignMessageClicked() {
 }
 
 void SettingsWidget::onConfigurationClicked() {
-    if (ui->pushButtonConfiguration->isChecked()) {
-        ui->configurationButtonsWidget->setVisible(true);
-
-        ui->optionsButtonsWidget->setVisible(false);
-        ui->toolsButtonsWidget->setVisible(false);
-        ui->fileButtonsWidget->setVisible(false);
-        ui->helpButtonsWidget->setVisible(false);
-        ui->pushButtonOptions->setChecked(false);
-        ui->pushButtonTools->setChecked(false);
-        ui->pushButtonFile->setChecked(false);
-        ui->pushButtonHelp->setChecked(false);
-
-    } else {
-        ui->configurationButtonsWidget->setVisible(false);
-    }
+    selectMenu(ui->pushButtonConfiguration);
 }
 
 void SettingsWidget::onBipToolClicked() {
@@ -291,22 +301,13 @@ void SettingsWidget::onMultisendClicked() {
     selectOption(ui->pushButtonFile3);
 }
 
+void SettingsWidget::onExportCSVClicked() {
+    ui->stackedWidgetContainer->setCurrentWidget(settingsExportCsvWidget);
+    selectOption(ui->pushButtonExportCsv);
+}
+
 void SettingsWidget::onOptionsClicked() {
-    if (ui->pushButtonOptions->isChecked()) {
-        ui->optionsButtonsWidget->setVisible(true);
-
-        ui->fileButtonsWidget->setVisible(false);
-        ui->toolsButtonsWidget->setVisible(false);
-        ui->configurationButtonsWidget->setVisible(false);
-        ui->helpButtonsWidget->setVisible(false);
-        ui->pushButtonFile->setChecked(false);
-        ui->pushButtonTools->setChecked(false);
-        ui->pushButtonConfiguration->setChecked(false);
-        ui->pushButtonHelp->setChecked(false);
-
-    } else {
-        ui->optionsButtonsWidget->setVisible(false);
-    }
+    selectMenu(ui->pushButtonOptions);
 }
 
 void SettingsWidget::onMainOptionsClicked() {
@@ -326,21 +327,7 @@ void SettingsWidget::onDisplayOptionsClicked() {
 
 
 void SettingsWidget::onToolsClicked() {
-    if (ui->pushButtonTools->isChecked()) {
-        ui->toolsButtonsWidget->setVisible(true);
-
-        ui->optionsButtonsWidget->setVisible(false);
-        ui->fileButtonsWidget->setVisible(false);
-        ui->configurationButtonsWidget->setVisible(false);
-        ui->helpButtonsWidget->setVisible(false);
-        ui->pushButtonOptions->setChecked(false);
-        ui->pushButtonFile->setChecked(false);
-        ui->pushButtonConfiguration->setChecked(false);
-        ui->pushButtonHelp->setChecked(false);
-
-    } else {
-        ui->toolsButtonsWidget->setVisible(false);
-    }
+  selectMenu(ui->pushButtonTools);
 }
 
 void SettingsWidget::onInformationClicked() {
@@ -367,20 +354,7 @@ void SettingsWidget::onWalletRepairClicked() {
 
 
 void SettingsWidget::onHelpClicked() {
-    if (ui->pushButtonHelp->isChecked()) {
-        ui->helpButtonsWidget->setVisible(true);
-
-        ui->toolsButtonsWidget->setVisible(false);
-        ui->optionsButtonsWidget->setVisible(false);
-        ui->fileButtonsWidget->setVisible(false);
-        ui->configurationButtonsWidget->setVisible(false);
-        ui->pushButtonOptions->setChecked(false);
-        ui->pushButtonFile->setChecked(false);
-        ui->pushButtonConfiguration->setChecked(false);
-        ui->pushButtonTools->setChecked(false);
-    } else {
-        ui->helpButtonsWidget->setVisible(false);
-    }
+    selectMenu(ui->pushButtonHelp);
 }
 
 void SettingsWidget::onAboutClicked() {
@@ -412,7 +386,8 @@ void SettingsWidget::setMapper(){
     settingsDisplayOptionsWidget->setMapper(mapper);
 }
 
-bool SettingsWidget::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn){
+bool SettingsWidget::openStandardDialog(const QString& title, const QString& body, const QString& okBtn, const QString& cancelBtn)
+{
     showHideOp(true);
     DefaultDialog *confirmDialog = new DefaultDialog(window);
     confirmDialog->setText(title, body, okBtn, cancelBtn);

--- a/src/qt/epgc/settings/settingswidget.h
+++ b/src/qt/epgc/settings/settingswidget.h
@@ -8,6 +8,7 @@
 #include <QWidget>
 #include "qt/epgc/pwidget.h"
 #include "qt/epgc/settings/settingsbackupwallet.h"
+#include "qt/epgc/settings/settingsexportcsv.h"
 #include "qt/epgc/settings/settingsbittoolwidget.h"
 #include "qt/epgc/settings/settingssignmessagewidgets.h"
 #include "qt/epgc/settings/settingswalletrepairwidget.h"
@@ -55,6 +56,7 @@ private slots:
     void onConfigurationClicked();
     void onBipToolClicked();
     void onMultisendClicked();
+    void onExportCSVClicked();
 
     // Options
     void onOptionsClicked();
@@ -76,11 +78,14 @@ private slots:
 
     void onResetAction();
     void onSaveOptionsClicked();
+
 private:
     Ui::SettingsWidget *ui;
+    int navAreaBaseHeight{0};
 
     SettingsBackupWallet *settingsBackupWallet;
     SettingsBitToolWidget *settingsBitToolWidget;
+    SettingsExportCSV *settingsExportCsvWidget;
     SettingsSignMessageWidgets *settingsSingMessageWidgets;
     SettingsWalletRepairWidget *settingsWalletRepairWidget;
     SettingsWalletOptionsWidget *settingsWalletOptionsWidget;
@@ -93,9 +98,12 @@ private:
     QDataWidgetMapper* mapper;
 
     QList<QPushButton*> options;
+    // Map of: menu button -> sub menu items
+    QMap <QPushButton*, QWidget*> menus;
 
     void selectOption(QPushButton* option);
-    bool openStandardDialog(QString title = "", QString body = "", QString okBtn = "OK", QString cancelBtn = "");
+    bool openStandardDialog(const QString& title = "", const QString& body = "", const QString& okBtn = "OK", const QString& cancelBtn = "");
+    void selectMenu(QPushButton* btn);
 };
 
 #endif // SETTINGSWIDGET_H


### PR DESCRIPTION
1. [GUI] Export csv files. # 1353
PR adding export CSV files functionality. (it's in a full screen to be able to add the export addresses (internal and remote), transactions/addresses filters, plus any other csv export functionality organized in a single location).

2. [GUI] One-click export to file # 1424
Export to file directly, after selecting the destination and clicking "Save", without requiring additional button presses.
Interested flows:

-   backup wallet
-   export txes to csv
-  export addresses to csv

3. [GUI] Settings widget, expand/collapse scroll area. # 1454


