### PR TITLE
Remove references to old command list-conf

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -434,7 +434,7 @@ UniValue startmasternode (const UniValue& params, bool fHelp)
 
         if(!found) {
             statusObj.push_back(Pair("success", false));
-            statusObj.push_back(Pair("error_message", "Could not find alias in config. Verify with list-conf."));
+            statusObj.push_back(Pair("error_message", "Could not find alias in config. Verify with listmasternodeconf."));
         }
 
         return statusObj;
@@ -829,7 +829,7 @@ UniValue createmasternodebroadcast(const UniValue& params, bool fHelp)
 
         if(!found) {
             statusObj.push_back(Pair("success", false));
-            statusObj.push_back(Pair("error_message", "Could not find alias in config. Verify with list-conf."));
+            statusObj.push_back(Pair("error_message", "Could not find alias in config. Verify with listmasternodeconf."));
         }
 
         return statusObj;


### PR DESCRIPTION
[Trivial][RPC] Remove references to old command list-conf  # 1497

startmasternode and createmasternodebroadcast error outputs are still
referencing old command list-conf
Replace with listmasternodeconf.