### PR TITLE
Add WITH_LOCK macro

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -189,6 +189,16 @@ public:
         LeaveCritical();           \
     }
 
+//! Run code while locking a mutex.
+//!
+//! Examples:
+//!
+//!   WITH_LOCK(cs, shared_val = shared_val + 1);
+//!
+//!   int val = WITH_LOCK(cs, return shared_val);
+//!
+#define WITH_LOCK(cs, code) [&] { LOCK(cs); code; }()
+
 class CSemaphore
 {
 private:


### PR DESCRIPTION
Add WITH_LOCK macro: run code while locking a mutex # 1325

Pretty useful functionality. Pushing it on its own separated PR to be able to use it in several open PRs.

Coming from btc@edfe943.