### PR TITLE
Set '-staking' disabled by default on RegTest

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1990,7 +1990,7 @@ bool AppInit2()
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
 
         // StakeMiner thread disabled by default on regtest
-        if (GetBoolArg("-staking", true)) {
+        if (GetBoolArg("-staking", !Params().IsRegTestNet())) {
             threadGroup.create_thread(boost::bind(&ThreadStakeMinter));
         }
     }


### PR DESCRIPTION
Hardcoded default false value, instead of having it in the config file for the test nodes.