### PR TITLE
Zerocoin cleanup 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ set(WALLET_SOURCES
         ./src/zepg/zepgwallet.cpp
         ./src/zepg/zepgtracker.cpp
         ./src/zepg/zepgmodule.cpp
+        ./src/zepg/zpos.cpp
         ./src/stakeinput.cpp
         )
 add_library(WALLET_A STATIC ${BitcoinHeaders} ${WALLET_SOURCES})

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -190,6 +190,7 @@ BITCOIN_CORE_H = \
   zepg/zepgtracker.h \
   zepg/zepgwallet.h \
   zepg/zepgmodule.h \
+  zepg/zpos.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h \
   zmq/zmqnotificationinterface.h \
@@ -285,6 +286,7 @@ libbitcoin_wallet_a_SOURCES = \
   zepg/zepgtracker.cpp \
   stakeinput.cpp \
   zepg/zepgmodule.cpp \
+  zepg/zpos.cpp \
   $(BITCOIN_CORE_H)
 
 # crypto primitives library

--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -16,6 +16,7 @@
 class CBasicKeyStore;
 class CWallet;
 class uint256;
+class CBlockIndex;
 
 /** General change type (added, updated, removed). */
 enum ChangeType {
@@ -102,7 +103,7 @@ public:
     boost::signals2::signal<void(const std::string& title, int nProgress)> ShowProgress;
 
     /** New block has been accepted */
-    boost::signals2::signal<void(const uint256& hash)> NotifyBlockTip;
+    boost::signals2::signal<void(bool fInitialDownload, const CBlockIndex* newTip)> NotifyBlockTip;
 
     /** New block has been accepted and is over a certain size */
     boost::signals2::signal<void(int size, const uint256& hash)> NotifyBlockSize;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -621,12 +621,19 @@ std::string LicenseInfo()
            "\n";
 }
 
-static void BlockNotifyCallback(const uint256& hashNewTip)
+static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex)
 {
+
+    if (initialSync || !pBlockIndex)
+        return;
+
     std::string strCmd = GetArg("-blocknotify", "");
 
-    boost::replace_all(strCmd, "%s", hashNewTip.GetHex());
-    boost::thread t(runCommand, strCmd); // thread runs free
+    if (!strCmd.empty()) {
+        boost::replace_all(strCmd, "%s", pBlockIndex->GetBlockHash().GetHex());
+        std::thread t(runCommand, strCmd);
+        t.detach(); // thread runs free
+    }
 }
 
 static void BlockSizeNotifyCallback(int size, const uint256& hashNewTip)
@@ -1549,7 +1556,7 @@ bool AppInit2()
                     {
                         LOCK(cs_main);
                         CBlockIndex *tip = chainActive[chainActive.Height()];
-                        RPCNotifyBlockChange(tip->GetBlockHash());
+                        RPCNotifyBlockChange(true, tip);
                         if (tip && tip->nTime > GetAdjustedTime() + 2 * 60 * 60) {
                             strLoadError = _("The block database contains a block which appears to be from the future. "
                                              "This may be due to your computer's date and time being set incorrectly. "

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -14,27 +14,245 @@
 #include "stakeinput.h"
 #include "utilmoneystr.h"
 #include "zepgchain.h"
+#include "zepg/zpos.h"
 
-// v1 modifier interval.
+/*
+ * PoS Validation
+ */
+
+bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet) {
+    // Grab the stake data
+    CBlockIndex* pindexfrom = stake->GetIndexFrom();
+    if (!pindexfrom) return error("%s : Failed to find the block index for stake origin", __func__);
+    const CDataStream& ssUniqueID = stake->GetUniqueness();
+    const unsigned int nTimeBlockFrom = pindexfrom->nTime;
+    CDataStream modifier_ss(SER_GETHASH, 0);
+
+    // Hash the modifier
+    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1)) {
+        // Modifier v1
+        uint64_t nStakeModifier = 0;
+        if (!GetOldStakeModifier(stake, nStakeModifier))
+            return error("%s : Failed to get kernel stake modifier", __func__);
+        modifier_ss << nStakeModifier;
+    } else {
+        // Modifier v2
+        modifier_ss << pindexPrev->nStakeModifierV2;
+    }
+
+    CDataStream ss(modifier_ss);
+    // Calculate hash
+    ss << nTimeBlockFrom << ssUniqueID << nTimeTx;
+    hashProofOfStakeRet = Hash(ss.begin(), ss.end());
+
+    if (fVerify) {
+        LogPrint("staking", "%s : nStakeModifier=%s\nnTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
+            __func__, HexStr(modifier_ss), nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
+    }
+    return true;
+}
+
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify)
+{
+    // Calculate the proof of stake hash
+    if (!GetHashProofOfStake(pindexPrev, stake, nTimeTx, fVerify, hashProofOfStake)) {
+        return error("%s : Failed to calculate the proof of stake hash", __func__);
+    }
+
+    const CAmount& nValueIn = stake->GetValue();
+    const CDataStream& ssUniqueID = stake->GetUniqueness();
+
+    // Base target
+    uint256 bnTarget;
+    bnTarget.SetCompact(nBits);
+
+    // Weighted target
+    uint256 bnWeight = uint256(nValueIn) / 100;
+    bnTarget *= bnWeight;
+
+    // Check if proof-of-stake hash meets target protocol
+    const bool res = (hashProofOfStake < bnTarget);
+
+    if (fVerify || res) {
+        LogPrint("staking", "%s : Proof Of Stake:"
+                            "\nssUniqueID=%s"
+                            "\nnTimeTx=%d"
+                            "\nhashProofOfStake=%s"
+                            "\nnBits=%d"
+                            "\nweight=%d"
+                            "\nbnTarget=%s (res: %d)\n\n",
+            __func__, HexStr(ssUniqueID), nTimeTx, hashProofOfStake.GetHex(),
+            nBits, nValueIn, bnTarget.GetHex(), res);
+    }
+    return res;
+}
+
+bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight)
+{
+    // Initialize the stake object
+    if(!initStakeInput(block, stake, nPreviousBlockHeight))
+        return error("%s : stake input object initialization failed", __func__);
+
+    const CTransaction tx = block.vtx[1];
+    // Kernel (input 0) must match the stake hash target per coin age (nBits)
+    const CTxIn& txin = tx.vin[0];
+    CBlockIndex* pindexPrev = mapBlockIndex[block.hashPrevBlock];
+    CBlockIndex* pindexfrom = stake->GetIndexFrom();
+    if (!pindexfrom)
+        return error("%s : Failed to find the block index for stake origin", __func__);
+
+    unsigned int nBlockFromTime = pindexfrom->nTime;
+    unsigned int nTxTime = block.nTime;
+    const int nBlockFromHeight = pindexfrom->nHeight;
+
+    if (!txin.IsZerocoinSpend() && nPreviousBlockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled() - 1) {
+        //check for maturity (min age/depth) requirements
+        if (!Params().HasStakeMinAgeOrDepth(nPreviousBlockHeight+1, nTxTime, nBlockFromHeight, nBlockFromTime))
+            return error("%s : min age violation - height=%d - nTimeTx=%d, nTimeBlockFrom=%d, nHeightBlockFrom=%d",
+                             __func__, nPreviousBlockHeight, nTxTime, nBlockFromTime, nBlockFromHeight);
+    }
+
+    if (!CheckStakeKernelHash(pindexPrev, block.nBits, stake.get(), nTxTime, hashProofOfStake, true))
+        return error("%s : INFO: check kernel failed on coinstake %s, hashProof=%s", __func__,
+                     tx.GetHash().GetHex(), hashProofOfStake.GetHex());
+
+    return true;
+}
+
+// Initialize the stake input object
+bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight) {
+    const CTransaction tx = block.vtx[1];
+    if (!tx.IsCoinStake())
+        return error("%s : called on non-coinstake %s", __func__, tx.GetHash().ToString().c_str());
+
+    // Kernel (input 0) must match the stake hash target per coin age (nBits)
+    const CTxIn& txin = tx.vin[0];
+
+    // Construct the stakeinput object
+    if (txin.IsZerocoinSpend()) {
+        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
+        if (spend.getSpendType() != libzerocoin::SpendType::STAKE)
+            return error("%s : spend is using the wrong SpendType (%d)", __func__, (int)spend.getSpendType());
+
+        stake = std::unique_ptr<CStakeInput>(new CLegacyZEpgStake(spend));
+
+        // zPoS contextual checks
+        /* Only for IBD (between Zerocoin_Block_V2_Start and Zerocoin_Block_Last_Checkpoint) */
+        if (nPreviousBlockHeight < Params().Zerocoin_Block_V2_Start() ||
+                nPreviousBlockHeight > Params().Zerocoin_Block_Last_Checkpoint())
+            return error("%s : zEPG stake block: height %d outside range", __func__, (nPreviousBlockHeight+1));
+        CLegacyZEpgStake* zEPG = dynamic_cast<CLegacyZEpgStake*>(stake.get());
+        if (!zEPG) return error("%s : dynamic_cast of stake ptr failed", __func__);
+        // The checkpoint needs to be from 200 blocks ago
+        const int cpHeight = nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth();
+        const libzerocoin::CoinDenomination denom = libzerocoin::AmountToZerocoinDenomination(zEPG->GetValue());
+        if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != zEPG->GetChecksum())
+            return error("%s : accum. checksum at height %d is wrong.", __func__, (nPreviousBlockHeight+1));
+
+    } else {
+        // First try finding the previous transaction in database
+        uint256 hashBlock;
+        CTransaction txPrev;
+        if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
+            return error("%s : INFO: read txPrev failed, tx id prev: %s, block id %s",
+                         __func__, txin.prevout.hash.GetHex(), block.GetHash().GetHex());
+
+        //verify signature and script
+        ScriptError serror;
+        if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0), &serror)) {
+            std::string strErr = "";
+            if (serror && ScriptErrorString(serror))
+                strErr = strprintf("with the following error: %s", ScriptErrorString(serror));
+            return error("%s : VerifyScript failed on coinstake %s %s", __func__, tx.GetHash().ToString(), strErr);
+        }
+
+        CEpgStake* epgInput = new CEpgStake();
+        epgInput->SetInput(txPrev, txin.prevout.n);
+        stake = std::unique_ptr<CStakeInput>(epgInput);
+    }
+    return true;
+}
+
+// Stake Modifier (hash modifier of proof-of-stake):
+// The purpose of stake modifier is to prevent a txout (coin) owner from
+// computing future proof-of-stake generated by this txout at the time
+// of transaction confirmation. To meet kernel protocol, the txout
+// must hash with a future stake modifier to generate the proof.
+uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel)
+{
+    // genesis block's modifier is 0
+    // all block's modifiers are 0 on regtest
+    if (!pindexPrev || Params().IsRegTestNet())
+        return uint256();
+
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << kernel;
+
+    // switch with old modifier on upgrade block
+    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1))
+        ss << pindexPrev->nStakeModifier;
+    else
+        ss << pindexPrev->nStakeModifierV2;
+
+    return ss.GetHash();
+}
+
+bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake)
+{
+    const int nHeight = pindexPrev->nHeight + 1;
+    // get stake input pindex
+    CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
+    if (!pindexFrom || pindexFrom->nHeight < 1) return error("%s : no pindexfrom", __func__);
+
+    // check required min depth for stake
+    const int nHeightBlockFrom = pindexFrom->nHeight;
+    if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
+        return error("%s : min depth violation, nHeight=%d, nHeightBlockFrom=%d", __func__, nHeight, nHeightBlockFrom);
+
+    nTimeTx = (Params().IsRegTestNet() ? GetAdjustedTime() : GetCurrentTimeSlot());
+    // double check that we are not on the same slot as prev block
+    if (nTimeTx <= pindexPrev->nTime) return false;
+
+    // check stake kernel
+    return CheckStakeKernelHash(pindexPrev, nBits, stakeInput, nTimeTx, hashProofOfStake);
+}
+
+
+/*
+ * UTILS
+ */
+
+// Timestamp for time protocol V2: slot duration 15 seconds
+int64_t GetTimeSlot(const int64_t nTime)
+{
+    const int slotLen = Params().TimeSlotLength();
+    return (nTime / slotLen) * slotLen;
+}
+
+int64_t GetCurrentTimeSlot()
+{
+    return GetTimeSlot(GetAdjustedTime());
+}
+
+uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom)
+{
+    int pos = distance(libzerocoin::zerocoinDenomList.begin(),
+            find(libzerocoin::zerocoinDenomList.begin(), libzerocoin::zerocoinDenomList.end(), denom));
+    nCheckpoint = nCheckpoint >> (32*((libzerocoin::zerocoinDenomList.size() - 1) - pos));
+    return nCheckpoint.Get32();
+}
+
+
+/*
+ * OLD MODIFIER
+ */
+static const unsigned int MODIFIER_INTERVAL = 60;
+static const int MODIFIER_INTERVAL_RATIO = 3;
 static const int64_t OLD_MODIFIER_INTERVAL = 2087;
 
 // Hard checkpoints of stake modifiers to ensure they are deterministic
 static std::map<int, unsigned int> mapStakeModifierCheckpoints =
     boost::assign::map_list_of(0, 0xfd11f4e7u);
-
-// Get the last stake modifier and its generation time from a given block
-static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64_t& nStakeModifier, int64_t& nModifierTime)
-{
-    if (!pindex)
-        return error("%s : null pindex", __func__);
-    while (pindex && pindex->pprev && !pindex->GeneratedStakeModifier())
-        pindex = pindex->pprev;
-    if (!pindex->GeneratedStakeModifier())
-        return error("%s : no generation at genesis block", __func__);
-    nStakeModifier = pindex->nStakeModifier;
-    nModifierTime = pindex->GetBlockTime();
-    return true;
-}
 
 // Get selection interval section (in seconds)
 static int64_t GetStakeModifierSelectionIntervalSection(int nSection)
@@ -107,30 +325,74 @@ static bool SelectBlockFromCandidates(
     return fSelected;
 }
 
-/* NEW MODIFIER */
-
-// Stake Modifier (hash modifier of proof-of-stake):
-// The purpose of stake modifier is to prevent a txout (coin) owner from
-// computing future proof-of-stake generated by this txout at the time
-// of transaction confirmation. To meet kernel protocol, the txout
-// must hash with a future stake modifier to generate the proof.
-uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel)
+unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    // genesis block's modifier is 0
-    // all block's modifiers are 0 on regtest
-    if (!pindexPrev || Params().IsRegTestNet())
-        return uint256();
+    assert(pindex->pprev || pindex->GetBlockHash() == Params().HashGenesisBlock());
+    // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
+    CDataStream ss(SER_GETHASH, 0);
+    if (pindex->pprev)
+        ss << pindex->pprev->nStakeModifierChecksum;
+    ss << pindex->nFlags << pindex->hashProofOfStake << pindex->nStakeModifier;
+    uint256 hashChecksum = Hash(ss.begin(), ss.end());
+    hashChecksum >>= (256 - 32);
+    return hashChecksum.Get64();
+}
 
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << kernel;
+bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier)
+{
+    if(Params().IsRegTestNet()) {
+        nStakeModifier = 0;
+        return true;
+    }
+    CBlockIndex* pindexFrom = stake->GetIndexFrom();
+    if (!pindexFrom) return error("%s : failed to get index from", __func__);
+    if (stake->IsZEPG()) {
+        int64_t nTimeBlockFrom = pindexFrom->GetBlockTime();
+        const int nHeightStop = std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1);
+        while (pindexFrom && pindexFrom->nHeight + 1 <= nHeightStop) {
+            if (pindexFrom->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
+                nStakeModifier = pindexFrom->nAccumulatorCheckpoint.Get64();
+                return true;
+            }
+            pindexFrom = chainActive.Next(pindexFrom);
+        }
+        return false;
 
-    // switch with old modifier on upgrade block
-    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1))
-        ss << pindexPrev->nStakeModifier;
-    else
-        ss << pindexPrev->nStakeModifierV2;
+    } else if (!GetOldModifier(pindexFrom->GetBlockHash(), nStakeModifier))
+        return error("%s : failed to get kernel stake modifier", __func__);
 
-    return ss.GetHash();
+    return true;
+}
+
+// The stake modifier used to hash for a stake kernel is chosen as the stake
+// modifier about a selection interval later than the coin generating the kernel
+bool GetOldModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier)
+{
+    if (!mapBlockIndex.count(hashBlockFrom))
+        return error("%s : block not indexed", __func__);
+    const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
+    int64_t nStakeModifierTime = pindexFrom->GetBlockTime();
+    // Fixed stake modifier only for regtest
+    if (Params().IsRegTestNet()) {
+        nStakeModifier = pindexFrom->nStakeModifier;
+        return true;
+    }
+    const CBlockIndex* pindex = pindexFrom;
+    CBlockIndex* pindexNext = chainActive[pindex->nHeight + 1];
+
+    // loop to find the stake modifier later by a selection interval
+    do {
+        if (!pindexNext) {
+            // Should never happen
+            return error("%s : Null pindexNext, current block %s ", __func__, pindex->phashBlock->GetHex());
+        }
+        pindex = pindexNext;
+        if (pindex->GeneratedStakeModifier()) nStakeModifierTime = pindex->GetBlockTime();
+        pindexNext = chainActive[pindex->nHeight + 1];
+    } while (nStakeModifierTime < pindexFrom->GetBlockTime() + OLD_MODIFIER_INTERVAL);
+
+    nStakeModifier = pindex->nStakeModifier;
+    return true;
 }
 
 // Stake Modifier (hash modifier of proof-of-stake):
@@ -169,8 +431,11 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     // First find current stake modifier and its generation block time
     // if it's not old enough, return the same stake modifier
     int64_t nModifierTime = 0;
-    if (!GetLastStakeModifier(pindexPrev, nStakeModifier, nModifierTime))
-        return error("%s : unable to get last modifier", __func__);
+    const CBlockIndex* p = pindexPrev;
+    while (p && p->pprev && !p->GeneratedStakeModifier()) p = p->pprev;
+    if (!p->GeneratedStakeModifier()) return error("%s : unable to get last modifier", __func__);
+    nStakeModifier = p->nStakeModifier;
+    nModifierTime = p->GetBlockTime();
 
     if (GetBoolArg("-printstakemodifier", false))
         LogPrintf("%s : prev modifier= %s time=%s\n", __func__, std::to_string(nStakeModifier).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nModifierTime).c_str());
@@ -242,278 +507,3 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     fGeneratedStakeModifier = true;
     return true;
 }
-
-// The stake modifier used to hash for a stake kernel is chosen as the stake
-// modifier about a selection interval later than the coin generating the kernel
-bool GetKernelStakeModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake)
-{
-    nStakeModifier = 0;
-    // modifier 0 on RegTest
-    if (Params().IsRegTestNet()) {
-        return true;
-    }
-    if (!mapBlockIndex.count(hashBlockFrom))
-        return error("%s : block not indexed", __func__);
-    const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
-    nStakeModifierHeight = pindexFrom->nHeight;
-    nStakeModifierTime = pindexFrom->GetBlockTime();
-    // Fixed stake modifier only for regtest
-    if (Params().IsRegTestNet()) {
-        nStakeModifier = pindexFrom->nStakeModifier;
-        return true;
-    }
-    const CBlockIndex* pindex = pindexFrom;
-    CBlockIndex* pindexNext = chainActive[pindex->nHeight + 1];
-
-    // loop to find the stake modifier later by a selection interval
-    do {
-        if (!pindexNext) {
-            // Should never happen
-            return error("%s : Null pindexNext, current block %s ", __func__, pindex->phashBlock->GetHex());
-        }
-        pindex = pindexNext;
-        if (pindex->GeneratedStakeModifier()) {
-            nStakeModifierHeight = pindex->nHeight;
-            nStakeModifierTime = pindex->GetBlockTime();
-        }
-        pindexNext = chainActive[pindex->nHeight + 1];
-    } while (nStakeModifierTime < pindexFrom->GetBlockTime() + OLD_MODIFIER_INTERVAL);
-
-    nStakeModifier = pindex->nStakeModifier;
-    return true;
-}
-
-bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify)
-{
-    // Calculate the proof of stake hash
-    if (!GetHashProofOfStake(pindexPrev, stake, nTimeTx, fVerify, hashProofOfStake)) {
-        return error("%s : Failed to calculate the proof of stake hash", __func__);
-    }
-
-    const CAmount& nValueIn = stake->GetValue();
-
-    if (Params().StakingMinInput(pindexPrev->nHeight + 1) > nValueIn)
-        return error("%s : Failed to check coinstake min amount", __func__);
-
-    const CDataStream& ssUniqueID = stake->GetUniqueness();
-
-    // Base target
-    uint256 bnTarget;
-    bnTarget.SetCompact(nBits);
-
-    // Weighted target
-    uint256 bnWeight = uint256(nValueIn) / 100;
-    bnTarget *= bnWeight;
-
-    // Check if proof-of-stake hash meets target protocol
-    const bool res = (hashProofOfStake < bnTarget);
-
-    if (fVerify || res) {
-        LogPrint("staking", "%s : Proof Of Stake:"
-                            "\nssUniqueID=%s"
-                            "\nnTimeTx=%d"
-                            "\nhashProofOfStake=%s"
-                            "\nnBits=%d"
-                            "\nweight=%d"
-                            "\nbnTarget=%s (res: %d)\n\n",
-            __func__, HexStr(ssUniqueID), nTimeTx, hashProofOfStake.GetHex(),
-            nBits, nValueIn, bnTarget.GetHex(), res);
-    }
-    return res;
-}
-
-bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet) {
-    // Grab the stake data
-    CBlockIndex* pindexfrom = stake->GetIndexFrom();
-    if (!pindexfrom) return error("%s : Failed to find the block index for stake origin", __func__);
-    const CDataStream& ssUniqueID = stake->GetUniqueness();
-    const unsigned int nTimeBlockFrom = pindexfrom->nTime;
-    CDataStream modifier_ss(SER_GETHASH, 0);
-
-    // Hash the modifier
-    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1)) {
-        // Modifier v1
-        uint64_t nStakeModifier = 0;
-        if (!stake->GetModifier(nStakeModifier))
-            return error("%s : Failed to get kernel stake modifier", __func__);
-        modifier_ss << nStakeModifier;
-    } else {
-        // Modifier v2
-        modifier_ss << pindexPrev->nStakeModifierV2;
-    }
-
-    CDataStream ss(modifier_ss);
-    // Calculate hash
-    ss << nTimeBlockFrom << ssUniqueID << nTimeTx;
-    hashProofOfStakeRet = Hash(ss.begin(), ss.end());
-
-    if (fVerify) {
-        LogPrint("staking", "%s : nStakeModifier=%s (nStakeModifierHeight=%s)\n"
-                "nTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
-            __func__, HexStr(modifier_ss), ((stake->IsZEPG()) ? "Not available" : std::to_string(stake->getStakeModifierHeight())),
-            nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
-    }
-    return true;
-}
-
-bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake)
-{
-    const int nHeight = pindexPrev->nHeight + 1;
-
-    // get stake input pindex
-    CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
-    if (!pindexFrom || pindexFrom->nHeight < 1) return error("%s : no pindexfrom", __func__);
-
-    // check required min depth for stake
-    const int nHeightBlockFrom = pindexFrom->nHeight;
-    if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
-        return error("%s : min depth violation, nHeight=%d, nHeightBlockFrom=%d", __func__, nHeight, nHeightBlockFrom);
-
-    nTimeTx = (Params().IsRegTestNet() ? GetAdjustedTime() : GetCurrentTimeSlot());
-    // double check that we are not on the same slot as prev block
-    if (nTimeTx <= pindexPrev->nTime) return false;
-
-    // check stake kernel
-    return CheckStakeKernelHash(pindexPrev, nBits, stakeInput, nTimeTx, hashProofOfStake);
-}
-
-uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom)
-{
-    int pos = distance(libzerocoin::zerocoinDenomList.begin(),
-            find(libzerocoin::zerocoinDenomList.begin(), libzerocoin::zerocoinDenomList.end(), denom));
-    nCheckpoint = nCheckpoint >> (32*((libzerocoin::zerocoinDenomList.size() - 1) - pos));
-    return nCheckpoint.Get32();
-}
-
-/* Only for IBD (between Zerocoin_Block_V2_Start and Zerocoin_Block_Last_Checkpoint) */
-bool ContextualCheckZerocoinStake(int nPreviousBlockHeight, CStakeInput* stake)
-{
-    if (nPreviousBlockHeight < Params().Zerocoin_Block_V2_Start() ||
-            nPreviousBlockHeight > Params().Zerocoin_Block_Last_Checkpoint())
-        return error("%s : zEPG stake block: height %d outside range", __func__, (nPreviousBlockHeight+1));
-
-    CZEpgStake* zEPG = dynamic_cast<CZEpgStake*>(stake);
-    if (!zEPG) return error("%s : dynamic_cast of stake ptr failed", __func__);
-
-    // The checkpoint needs to be from 200 blocks ago
-    const int cpHeight = nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth();
-    const libzerocoin::CoinDenomination denom = libzerocoin::AmountToZerocoinDenomination(zEPG->GetValue());
-    if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != zEPG->GetChecksum())
-        return error("%s : accum. checksum at height %d is wrong.", __func__, (nPreviousBlockHeight+1));
-
-    return true;
-}
-
-bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight) {
-    const CTransaction tx = block.vtx[1];
-    if (!tx.IsCoinStake())
-        return error("%s : called on non-coinstake %s", __func__, tx.GetHash().ToString().c_str());
-
-    // Kernel (input 0) must match the stake hash target per coin age (nBits)
-    const CTxIn& txin = tx.vin[0];
-
-    //Construct the stakeinput object
-    if (txin.IsZerocoinSpend()) {
-        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
-        if (spend.getSpendType() != libzerocoin::SpendType::STAKE)
-            return error("%s : spend is using the wrong SpendType (%d)", __func__, (int)spend.getSpendType());
-
-        stake = std::unique_ptr<CStakeInput>(new CZEpgStake(spend));
-        if (!ContextualCheckZerocoinStake(nPreviousBlockHeight, stake.get()))
-            return error("%s : staked zEPG fails context checks", __func__);
-        
-    } else {
-        // First try finding the previous transaction in database
-        uint256 hashBlock;
-        CTransaction txPrev;
-        if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
-            return error("%s : INFO: read txPrev failed, tx id prev: %s, block id %s",
-                         __func__, txin.prevout.hash.GetHex(), block.GetHash().GetHex());
-
-        //verify signature and script
-        ScriptError serror;
-        if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0), &serror)) {
-            std::string strErr = "";
-            if (serror && ScriptErrorString(serror))
-                strErr = strprintf("with the following error: %s", ScriptErrorString(serror));
-            return error("%s : VerifyScript failed on coinstake %s %s", __func__, tx.GetHash().ToString(), strErr);
-        }
-
-        CEpgStake* epgInput = new CEpgStake();
-        epgInput->SetInput(txPrev, txin.prevout.n);
-        stake = std::unique_ptr<CStakeInput>(epgInput);
-    }
-    return true;
-}
-
-// Check kernel hash target and coinstake signature
-bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight)
-{
-    // Initialize the stake object
-    if(!initStakeInput(block, stake, nPreviousBlockHeight))
-        return error("%s : stake input object initialization failed", __func__);
-
-    const CTransaction tx = block.vtx[1];
-    // Kernel (input 0) must match the stake hash target per coin age (nBits)
-    const CTxIn& txin = tx.vin[0];
-    CBlockIndex* pindexPrev = mapBlockIndex[block.hashPrevBlock];
-    CBlockIndex* pindexfrom = stake->GetIndexFrom();
-    if (!pindexfrom)
-        return error("%s : Failed to find the block index for stake origin", __func__);
-
-    unsigned int nBlockFromTime = pindexfrom->nTime;
-    unsigned int nTxTime = block.nTime;
-    const int nBlockFromHeight = pindexfrom->nHeight;
-
-    if (!txin.IsZerocoinSpend() && nPreviousBlockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled() - 1) {
-        //check for maturity (min age/depth) requirements
-        if (!Params().HasStakeMinAgeOrDepth(nPreviousBlockHeight+1, nTxTime, nBlockFromHeight, nBlockFromTime))
-            return error("%s : min age violation - height=%d - nTimeTx=%d, nTimeBlockFrom=%d, nHeightBlockFrom=%d",
-                             __func__, nPreviousBlockHeight, nTxTime, nBlockFromTime, nBlockFromHeight);
-    }
-
-    if (!CheckStakeKernelHash(pindexPrev, block.nBits, stake.get(), nTxTime, hashProofOfStake, true))
-        return error("%s : INFO: check kernel failed on coinstake %s, hashProof=%s", __func__,
-                     tx.GetHash().GetHex(), hashProofOfStake.GetHex());
-
-    return true;
-}
-
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
-{
-    assert(pindex->pprev || pindex->GetBlockHash() == Params().HashGenesisBlock());
-    // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
-    CDataStream ss(SER_GETHASH, 0);
-    if (pindex->pprev)
-        ss << pindex->pprev->nStakeModifierChecksum;
-    ss << pindex->nFlags << pindex->hashProofOfStake << pindex->nStakeModifier;
-    uint256 hashChecksum = Hash(ss.begin(), ss.end());
-    hashChecksum >>= (256 - 32);
-    return hashChecksum.Get64();
-}
-
-// Check stake modifier hard checkpoints
-bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum)
-{
-    if (Params().NetworkID() != CBaseChainParams::MAIN) return true; // Testnet has no checkpoints
-    if (mapStakeModifierCheckpoints.count(nHeight)) {
-        return nStakeModifierChecksum == mapStakeModifierCheckpoints[nHeight];
-    }
-    return true;
-}
-
-// Timestamp for time protocol V2: slot duration 15 seconds
-int64_t GetTimeSlot(const int64_t nTime)
-{
-    const int slotLen = Params().TimeSlotLength();
-    return (nTime / slotLen) * slotLen;
-}
-
-int64_t GetCurrentTimeSlot()
-{
-    return GetTimeSlot(GetAdjustedTime());
-}
-
-
-

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,47 +1,37 @@
 // Copyright (c) 2011-2013 The PPCoin developers
 // Copyright (c) 2013-2014 The NovaCoin Developers
 // Copyright (c) 2014-2018 The BlackCoin Developers
-// Copyright (c) 2015-2019 The PIVX developers
+// Copyright (c) 2015-2020 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_H
-#define BITCOIN_KERNEL_H
+#ifndef EPGC_KERNEL_H
+#define EPGC_KERNEL_H
 
 #include "main.h"
 #include "stakeinput.h"
 
-
-// MODIFIER_INTERVAL: time to elapse before new modifier is computed
-static const unsigned int MODIFIER_INTERVAL = 60;
-
-// MODIFIER_INTERVAL_RATIO:
-// ratio of group interval length between the last group and the first group
-static const int MODIFIER_INTERVAL_RATIO = 3;
-
-// Compute the hash modifier for proof-of-stake
-bool GetKernelStakeModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake);
-bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
-uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
-bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
-
+/* PoS Validation */
+bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet);
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify = false);
+bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
 // Initialize the stake input object
 bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
+// (New) Stake Modifier
+uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
+// Stake (find valid kernel)
+bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
 
-// Check kernel hash target and coinstake signature
-// Sets hashProofOfStake on success return
-bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
-bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify = false);
-// Returns the proof of stake hash
-bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet);
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
-
-// Check stake modifier hard checkpoints
-bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum);
-
+/* Utils */
 int64_t GetTimeSlot(const int64_t nTime);
 int64_t GetCurrentTimeSlot();
 uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom);
 
-#endif // BITCOIN_KERNEL_H
+
+/* Old Stake Modifier */
+unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
+bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier);
+bool GetOldModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier);
+bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
+
+#endif // EPGC_KERNEL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3909,8 +3909,6 @@ CBlockIndex* AddToBlockIndex(const CBlock& block)
                 LogPrintf("AddToBlockIndex() : ComputeNextStakeModifier() failed \n");
             pindexNew->SetStakeModifier(nStakeModifier, fGeneratedStakeModifier);
             pindexNew->nStakeModifierChecksum = GetStakeModifierChecksum(pindexNew);
-            if (!CheckStakeModifierCheckpoints(pindexNew->nHeight, pindexNew->nStakeModifierChecksum))
-                LogPrintf("AddToBlockIndex() : Rejected by stake modifier checkpoint height=%d, modifier=%s \n", pindexNew->nHeight, std::to_string(nStakeModifier));
         } else {
             // compute v2 stake modifier
             pindexNew->nStakeModifierV2 = ComputeStakeModifier(pindexNew->pprev, block.vtx[1].vin[0].prevout.hash);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3729,11 +3729,12 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
  */
 bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChecked)
 {
-    CBlockIndex* pindexNewTip = NULL;
-    CBlockIndex* pindexMostWork = NULL;
+    CBlockIndex* pindexNewTip = nullptr;
+    CBlockIndex* pindexMostWork = nullptr;
     do {
         boost::this_thread::interruption_point();
 
+        const CBlockIndex *pindexFork;
         bool fInitialDownload;
         while (true) {
             TRY_LOCK(cs_main, lockMain);
@@ -3742,6 +3743,7 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChe
                 continue;
             }
 
+            CBlockIndex *pindexOldTip = chainActive.Tip();
             pindexMostWork = FindMostWorkChain();
 
             // Whether we have anything to do at all.
@@ -3752,34 +3754,43 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChe
                 return false;
 
             pindexNewTip = chainActive.Tip();
+            pindexFork = chainActive.FindFork(pindexOldTip);
             fInitialDownload = IsInitialBlockDownload();
             break;
         }
+
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
-
         // Notifications/callbacks that can run without cs_main
-        if (!fInitialDownload) {
-            uint256 hashNewTip = pindexNewTip->GetBlockHash();
-            // Relay inventory, but don't relay old inventory during initial block download.
-            int nBlockEstimate = Checkpoints::GetTotalBlocksEstimate();
-            {
-                LOCK(cs_vNodes);
-                for (CNode* pnode : vNodes)
-                    if (chainActive.Height() > (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
-                        pnode->PushInventory(CInv(MSG_BLOCK, hashNewTip));
-            }
-            // Notify external listeners about the new tip.
-            // Note: uiInterface, should switch main signals.
-            uiInterface.NotifyBlockTip(hashNewTip);
-            GetMainSignals().UpdatedBlockTip(pindexNewTip);
+        // Always notify the UI if a new block tip was connected
+        if (pindexFork != pindexNewTip) {
 
-            unsigned size = 0;
-            if (pblock)
-                size = GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
-            // If the size is over 1 MB notify external listeners, and it is within the last 5 minutes
-            if (size > MAX_BLOCK_SIZE_LEGACY && pblock->GetBlockTime() > GetAdjustedTime() - 300) {
-                uiInterface.NotifyBlockSize(static_cast<int>(size), hashNewTip);
+            // Notify the UI
+            uiInterface.NotifyBlockTip(fInitialDownload, pindexNewTip);
+
+            // Notifications/callbacks that can run without cs_main
+            if (!fInitialDownload) {
+                uint256 hashNewTip = pindexNewTip->GetBlockHash();
+                // Relay inventory, but don't relay old inventory during initial block download.
+                int nBlockEstimate = Checkpoints::GetTotalBlocksEstimate();
+                {
+                    LOCK(cs_vNodes);
+                    for (CNode *pnode : vNodes)
+                        if (chainActive.Height() >
+                            (pnode->nStartingHeight != -1 ? pnode->nStartingHeight - 2000 : nBlockEstimate))
+                            pnode->PushInventory(CInv(MSG_BLOCK, hashNewTip));
+                }
+                // Notify external listeners about the new tip.
+                GetMainSignals().UpdatedBlockTip(pindexNewTip);
+
+                unsigned size = 0;
+                if (pblock)
+                    size = GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
+                // If the size is over 1 MB notify external listeners, and it is within the last 5 minutes
+                if (size > MAX_BLOCK_SIZE_LEGACY && pblock->GetBlockTime() > GetAdjustedTime() - 300) {
+                    uiInterface.NotifyBlockSize(static_cast<int>(size), hashNewTip);
+                }
             }
+
         }
     } while (pindexMostWork != chainActive.Tip());
     CheckBlockIndex();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -30,6 +30,8 @@
 #include <QTimer>
 
 static const int64_t nClientStartupTime = GetTime();
+// Last tip update notification
+static int64_t nLastBlockTipUpdateNotification = 0;
 
 ClientModel::ClientModel(OptionsModel* optionsModel, QObject* parent) : QObject(parent),
                                                                         optionsModel(optionsModel),
@@ -133,29 +135,6 @@ void ClientModel::updateTimer()
     // Get required lock upfront. This avoids the GUI from getting stuck on
     // periodical polls if the core is holding the locks for a longer time -
     // for example, during a wallet rescan.
-    TRY_LOCK(cs_main, lockMain);
-    if (!lockMain)
-        return;
-    // Some quantities (such as number of blocks) change so fast that we don't want to be notified for each change.
-    // Periodically check and update with a timer.
-    int newNumBlocks = getNumBlocks();
-
-    static int prevAttempt = -1;
-    static int prevAssets = -1;
-
-    // check for changed number of blocks we have, number of blocks peers claim to have, reindexing state and importing state
-    if (cachedNumBlocks != newNumBlocks ||
-        cachedReindexing != fReindex || cachedImporting != fImporting ||
-        masternodeSync.RequestedMasternodeAttempt != prevAttempt || masternodeSync.RequestedMasternodeAssets != prevAssets) {
-        cachedNumBlocks = newNumBlocks;
-        cachedReindexing = fReindex;
-        cachedImporting = fImporting;
-        prevAttempt = masternodeSync.RequestedMasternodeAttempt;
-        prevAssets = masternodeSync.RequestedMasternodeAssets;
-
-        Q_EMIT numBlocksChanged(newNumBlocks);
-    }
-
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
 }
 
@@ -268,6 +247,27 @@ void ClientModel::updateBanlist()
     banTableModel->refresh();
 }
 
+static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CBlockIndex *pIndex)
+{
+    // lock free async UI updates in case we have a new block tip
+    // during initial sync, only update the UI if the last update
+    // was > 1000ms (MODEL_UPDATE_DELAY) ago
+    int64_t now = 0;
+    if (initialSync)
+        now = GetTimeMillis();
+
+    // if we are in-sync, update the UI regardless of last update time
+    if (!initialSync || now - nLastBlockTipUpdateNotification > MODEL_UPDATE_DELAY) {
+        //pass a async signal to the UI thread
+        int newHeight = pIndex->nHeight;
+        clientmodel->setCacheNumBlocks(newHeight);
+        clientmodel->setCacheImporting(fImporting);
+        clientmodel->setCacheReindexing(fReindex);
+        Q_EMIT clientmodel->numBlocksChanged(newHeight);
+        nLastBlockTipUpdateNotification = now;
+    }
+}
+
 // Handlers for core signals
 static void ShowProgress(ClientModel* clientmodel, const std::string& title, int nProgress)
 {
@@ -305,6 +305,7 @@ void ClientModel::subscribeToCoreSignals()
     uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, _1));
     uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, _1, _2));
     uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
+    uiInterface.NotifyBlockTip.connect(boost::bind(BlockTipChanged, this, _1, _2));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
@@ -314,6 +315,7 @@ void ClientModel::unsubscribeFromCoreSignals()
     uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, _1));
     uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, _1, _2));
     uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
+    uiInterface.NotifyBlockTip.disconnect(boost::bind(BlockTipChanged, this, _1, _2));
 }
 
 bool ClientModel::getTorInfo(std::string& ip_port) const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -79,6 +79,10 @@ public:
     QString formatClientStartupTime() const;
     QString dataDir() const;
 
+    void setCacheNumBlocks(int blockNum) { cachedNumBlocks = blockNum; };
+    void setCacheReindexing(bool reindex) { cachedReindexing = reindex; };
+    void setCacheImporting(bool import) { cachedImporting = import; };
+    
     bool getTorInfo(std::string& ip_port) const;
 
 private:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -580,7 +580,7 @@ bool WalletModel::createZepgSpend(
 
     CReserveKey reserveKey(wallet);
     std::vector<CDeterministicMint> vNewMints;
-    if (!wallet->CreateZerocoinSpendTransaction(
+    if (!wallet->CreateZCPublicSpendTransaction(
             value,
             wtxNew,
             reserveKey,

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -201,10 +201,8 @@ UniValue getbestblockhash(const UniValue& params, bool fHelp)
     return chainActive.Tip()->GetBlockHash().GetHex();
 }
 
-void RPCNotifyBlockChange(const uint256 hashBlock)
+void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex)
 {
-    CBlockIndex* pindex = nullptr;
-    pindex = mapBlockIndex.at(hashBlock);
     if(pindex) {
         std::lock_guard<std::mutex> lock(cs_blockchange);
         latestblock.hash = pindex->GetBlockHash();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -161,11 +161,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         if (!GetHashProofOfStake(blockindex->pprev, stake.get(), nTxTime, false, hashProofOfStakeRet))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot get proof of stake hash");
 
-        UniValue stakeData(UniValue::VOBJ);
-        stakeData.push_back(Pair("hashProofOfStake", hashProofOfStakeRet.GetHex()));
-        stakeData.push_back(Pair("stakeModifierHeight", ((stake->IsZEPG()) ? "Not available" : std::to_string(
-                stake->getStakeModifierHeight()))));
-        result.push_back(Pair("CoinStake", stakeData));
+        result.push_back(Pair("hashProofOfStake", hashProofOfStakeRet.GetHex()));
     }
 
     return result;
@@ -521,9 +517,7 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "     \"5000\" : n,         (numeric) supply of 5000 zEPG denomination\n"
             "     \"total\" : n,        (numeric) The total supply of all zEPG denominations\n"
             "  },\n"
-            "  \"CoinStake\" :\n"
-            "    \"hashProofOfStake\" : \"hash\",   (string) Proof of Stake hash\n"
-            "    \"stakeModifierHeight\" : \"nnn\"  (string) Stake modifier block height\n"
+            "  \"hashProofOfStake\" : \"hash\",   (string) Proof of Stake hash\n"
             "  }\n"
             "}\n"
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -917,104 +917,18 @@ UniValue getspentzerocoinamount(const UniValue& params, bool fHelp)
 }
 
 #ifdef ENABLE_WALLET
-UniValue createrawzerocoinstake(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() != 1)
-        throw std::runtime_error(
-            "createrawzerocoinstake mint_input \n"
-            "\nCreates raw zEPG coinstakes (without MN output). Only for regtest\n" +
-            HelpRequiringPassphrase() + "\n"
-
-            "\nArguments:\n"
-            "1. mint_input      (hex string, required) serial hash of the mint used as input\n"
-
-            "\nResult:\n"
-            "{\n"
-            "   \"hex\": \"xxx\",           (hex string) raw coinstake transaction\n"
-            "   \"private-key\": \"xxx\"    (hex string) private key of the input mint [needed to\n"
-            "                                            sign a block with this stake]"
-            "}\n"
-            "\nExamples\n" +
-            HelpExampleCli("createrawzerocoinstake", "0d8c16eee7737e3cc1e4e70dc006634182b175e039700931283b202715a0818f") +
-            HelpExampleRpc("createrawzerocoinstake", "0d8c16eee7737e3cc1e4e70dc006634182b175e039700931283b202715a0818f"));
-
-
-    if (!Params().IsRegTestNet())
-        throw JSONRPCError(RPC_WALLET_ERROR, "createrawzerocoinstake is available only on regtest net");
-
-    assert(pwalletMain != NULL);
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    if(sporkManager.IsSporkActive(SPORK_16_ZEROCOIN_MAINTENANCE_MODE))
-        throw JSONRPCError(RPC_WALLET_ERROR, "zEPG is currently disabled due to maintenance.");
-
-    std::string serial_hash = params[0].get_str();
-    if (!IsHex(serial_hash))
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex serial hash");
-
-    EnsureWalletIsUnlocked();
-
-    uint256 hashSerial(serial_hash);
-    CZerocoinMint input_mint;
-    if (!pwalletMain->GetMint(hashSerial, input_mint)) {
-        std::string strErr = "Failed to fetch mint associated with serial hash " + serial_hash;
-        throw JSONRPCError(RPC_WALLET_ERROR, strErr);
-    }
-
-    CMutableTransaction coinstake_tx;
-
-    // create the zerocoinmint output (one spent denom + three 1-zEPG denom)
-    libzerocoin::CoinDenomination staked_denom = input_mint.GetDenomination();
-    std::vector<CTxOut> vOutMint(5);
-    // Mark coin stake transaction
-    CScript scriptEmpty;
-    scriptEmpty.clear();
-    vOutMint[0] = CTxOut(0, scriptEmpty);
-    CDeterministicMint dMint;
-    if (!pwalletMain->CreateZEPGOutPut(staked_denom, vOutMint[1], dMint))
-        throw JSONRPCError(RPC_WALLET_ERROR, "failed to create new zepg output");
-
-    for (int i=2; i<5; i++) {
-        if (!pwalletMain->CreateZEPGOutPut(libzerocoin::ZQ_ONE, vOutMint[i], dMint))
-            throw JSONRPCError(RPC_WALLET_ERROR, "failed to create new zepg output");
-    }
-    coinstake_tx.vout = vOutMint;
-
-    //hash with only the output info in it to be used in Signature of Knowledge
-    uint256 hashTxOut = coinstake_tx.GetHash();
-    CZerocoinSpendReceipt receipt;
-
-    // create the zerocoinspend input
-    CTxIn newTxIn;
-    // !TODO: mint checks
-    if (!pwalletMain->MintToTxIn(input_mint, hashTxOut, newTxIn, receipt, libzerocoin::SpendType::STAKE, nullptr, false))
-        throw JSONRPCError(RPC_WALLET_ERROR, "failed to create zc-spend stake input");
-
-    coinstake_tx.vin.push_back(newTxIn);
-
-    UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("hex", EncodeHexTx(coinstake_tx)));
-    CPrivKey pk = input_mint.GetPrivKey();
-    CKey key;
-    key.SetPrivKey(pk, true);
-    ret.push_back(Pair("private-key", HexStr(key)));
-    return ret;
-
-}
 
 UniValue createrawzerocoinspend(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 3)
         throw std::runtime_error(
-            "createrawzerocoinspend mint_input ( \"address\" isPublicSpend )\n"
+            "createrawzerocoinspend mint_input ( \"address\" )\n"
             "\nCreates raw zEPG public spend.\n" +
             HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
             "1. mint_input      (hex string, required) serial hash of the mint used as input\n"
             "2. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
-            "3. isPublicSpend   (boolean, optional, default=true) create a public zc spend."
-            "                       If false, instead create spend version 2 (only for regression tests)"
 
 
             "\nResult:\n"
@@ -1027,7 +941,6 @@ UniValue createrawzerocoinspend(const UniValue& params, bool fHelp)
 
     const std::string serial_hash = params[0].get_str();
     const std::string address_str = (params.size() > 1 ? params[1].get_str() : "");
-    const bool isPublicSpend = (params.size() > 2 ? params[2].get_bool() : true);
 
     if (!IsHex(serial_hash))
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex serial hash");
@@ -1040,9 +953,6 @@ UniValue createrawzerocoinspend(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid EPGC address");
         addr_ptr = &address;
     }
-
-    if (!Params().IsRegTestNet() && !isPublicSpend)
-        throw JSONRPCError(RPC_WALLET_ERROR, "zEPG old spend only available in regtest for tests purposes");
 
     assert(pwalletMain != NULL);
     EnsureWalletIsUnlocked();
@@ -1066,7 +976,7 @@ UniValue createrawzerocoinspend(const UniValue& params, bool fHelp)
     if (addr_ptr) {
         outputs.push_back(std::pair<CBitcoinAddress*, CAmount>(addr_ptr, nAmount));
     }
-    if (!pwalletMain->CreateZerocoinSpendTransaction(nAmount, rawTx, reserveKey, receipt, vMintsSelected, vNewMints, false, true, outputs, nullptr, isPublicSpend))
+    if (!pwalletMain->CreateZCPublicSpendTransaction(nAmount, rawTx, reserveKey, receipt, vMintsSelected, vNewMints, false, true, outputs, nullptr))
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());
 
     // output the raw transaction

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -450,7 +450,6 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "delegatoradd", &delegatoradd, true, false, true},
         {"wallet", "delegatorremove", &delegatorremove, true, false, true},
 
-        {"zerocoin", "createrawzerocoinstake", &createrawzerocoinstake, false, false, true},
         {"zerocoin", "createrawzerocoinspend", &createrawzerocoinspend, false, false, true},
         {"zerocoin", "getzerocoinbalance", &getzerocoinbalance, false, false, true},
         {"zerocoin", "listmintedzerocoins", &listmintedzerocoins, false, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -359,6 +359,6 @@ bool StartRPC();
 void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const UniValue& vReq);
-void RPCNotifyBlockChange(const uint256 nHeight);
+void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex);
 
 #endif // BITCOIN_RPCSERVER_H

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -179,7 +179,7 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
-extern UniValue DoZepgSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend = true);
+extern UniValue DoZepgSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str);
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpc/net.cpp
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
@@ -291,7 +291,6 @@ extern UniValue decoderawtransaction(const UniValue& params, bool fHelp);
 extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
-extern UniValue createrawzerocoinstake(const UniValue& params, bool fHelp);
 extern UniValue createrawzerocoinspend(const UniValue& params, bool fHelp);
 
 extern UniValue findserial(const UniValue& params, bool fHelp); // in rpc/blockchain.cpp

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -18,7 +18,7 @@ bool CEpgStake::SetInput(CTransaction txPrev, unsigned int n)
     return true;
 }
 
-bool CPivStake::GetTxFrom(CTransaction& tx) const
+bool CEpgStake::GetTxFrom(CTransaction& tx) const
 {
     tx = txFrom;
     return true;
@@ -30,7 +30,7 @@ bool CEpgStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
     return true;
 }
 
-CAmount CPivStake::GetValue() const
+CAmount CEpgStake::GetValue() const
 {
     return txFrom.vout[nPosition].nValue;
 }
@@ -83,7 +83,7 @@ bool CEpgStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
     return true;
 }
 
-CDataStream CPivStake::GetUniqueness() const
+CDataStream CEpgStake::GetUniqueness() const
 {
     //The unique identifier for a EPG stake is the outpoint
     CDataStream ss(SER_NETWORK, 0);

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -22,52 +22,12 @@ public:
     virtual ~CStakeInput(){};
     virtual CBlockIndex* GetIndexFrom() = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) = 0;
-    virtual bool GetTxFrom(CTransaction& tx) = 0;
-    virtual CAmount GetValue() = 0;
+    virtual bool GetTxFrom(CTransaction& tx) const = 0;
+    virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
-    virtual bool GetModifier(uint64_t& nStakeModifier) = 0;
-    virtual bool IsZEPG() = 0;
-    virtual CDataStream GetUniqueness() = 0;
-    virtual uint256 GetSerialHash() const = 0;
+    virtual bool IsZEPG() const = 0;
+    virtual CDataStream GetUniqueness() const = 0;
 
-    virtual uint64_t getStakeModifierHeight() const {
-        return 0;
-    }
-};
-
-
-// zEPGStake can take two forms
-// 1) the stake candidate, which is a zcmint that is attempted to be staked
-// 2) a staked zepg, which is a zcspend that has successfully staked
-class CZEpgStake : public CStakeInput
-{
-private:
-    uint32_t nChecksum;
-    bool fMint;
-    libzerocoin::CoinDenomination denom;
-    uint256 hashSerial;
-
-public:
-    explicit CZEpgStake(libzerocoin::CoinDenomination denom, const uint256& hashSerial)
-    {
-        this->denom = denom;
-        this->hashSerial = hashSerial;
-        fMint = true;
-    }
-
-    explicit CZEpgStake(const libzerocoin::CoinSpend& spend);
-
-    CBlockIndex* GetIndexFrom() override;
-    bool GetTxFrom(CTransaction& tx) override;
-    CAmount GetValue() override;
-    bool GetModifier(uint64_t& nStakeModifier) override;
-    CDataStream GetUniqueness() override;
-    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override;
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
-    bool MarkSpent(CWallet* pwallet, const uint256& txid);
-    bool IsZEPG() override { return true; }
-    uint256 GetSerialHash() const override { return hashSerial; }
-    uint32_t GetChecksum();
 };
 
 class CEpgStake : public CStakeInput
@@ -76,26 +36,18 @@ private:
     CTransaction txFrom;
     unsigned int nPosition;
 
-    // cached data
-    uint64_t nStakeModifier = 0;
-    int nStakeModifierHeight = 0;
-    int64_t nStakeModifierTime = 0;
 public:
     CEpgStake(){}
 
     bool SetInput(CTransaction txPrev, unsigned int n);
 
     CBlockIndex* GetIndexFrom() override;
-    bool GetTxFrom(CTransaction& tx) override;
-    CAmount GetValue() override;
-    bool GetModifier(uint64_t& nStakeModifier) override;
-    CDataStream GetUniqueness() override;
+    bool GetTxFrom(CTransaction& tx) const override;
+    CAmount GetValue() const override;
+    CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override;
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
-    bool IsZEPG() override { return false; }
-    uint256 GetSerialHash() const override { return uint256(0); }
-
-    uint64_t getStakeModifierHeight() const override { return nStakeModifierHeight; }
+    bool IsZEPG() const override { return false; }
 };
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3442,7 +3442,7 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 5 || params.size() < 3)
         throw std::runtime_error(
-            "spendzerocoin amount mintchange minimizechange ( \"address\" isPublicSpend)\n"
+            "spendzerocoin amount mintchange minimizechange ( \"address\" )\n"
             "\nSpend zEPG to a EPG address.\n" +
             HelpRequiringPassphrase() + "\n"
 
@@ -3452,8 +3452,6 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
             "3. minimizechange  (boolean, required) Try to minimize the returning change  [false]\n"
             "4. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
             "                       If there is change then an address is required\n"
-            "5. isPublicSpend   (boolean, optional, default=true) create a public zc spend."
-            "                       If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -3491,18 +3489,12 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
     const bool fMintChange = params[1].get_bool();       // Mint change to zEPG
     const bool fMinimizeChange = params[2].get_bool();    // Minimize change
     const std::string address_str = (params.size() > 3 ? params[3].get_str() : "");
-    const bool isPublicSpend = (params.size() > 4 ? params[4].get_bool() : true);
 
-    if (!Params().IsRegTestNet()) {
-        if (fMintChange)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zEPG minting is DISABLED (except for regtest), cannot mint change");
-
-        if (!isPublicSpend)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zEPG old spend only available in regtest for tests purposes");
-    }
+    if (!Params().IsRegTestNet() && fMintChange)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zEpg minting is DISABLED (except for regtest), cannot mint change");
 
     std::vector<CZerocoinMint> vMintsSelected;
-    return DoZepgSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str, isPublicSpend);
+    return DoZepgSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str);
 }
 
 
@@ -3510,15 +3502,13 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 3)
         throw std::runtime_error(
-            "spendzerocoinmints mints_list (\"address\" isPublicSpend) \n"
+            "spendzerocoinmints mints_list ( \"address\" ) \n"
             "\nSpend zEPG mints to a EPG address.\n" +
             HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
             "1. mints_list     (string, required) A json array of zerocoin mints serial hashes\n"
             "2. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
-            "3. isPublicSpend  (boolean, optional, default=true) create a public zc spend."
-            "                       If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -3554,14 +3544,9 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 
     UniValue arrMints = params[0].get_array();
     const std::string address_str = (params.size() > 1 ? params[1].get_str() : "");
-    const bool isPublicSpend = (params.size() > 2 ? params[2].get_bool() : true);
 
     if (arrMints.size() == 0)
         throw JSONRPCError(RPC_WALLET_ERROR, "No zerocoin selected");
-
-    if (!isPublicSpend && !Params().IsRegTestNet()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "zEPG old spend only available in regtest for tests purposes");
-    }
 
     // check mints supplied and save serial hash (do this here so we don't fetch if any is wrong)
     std::vector<uint256> vSerialHashes;
@@ -3585,20 +3570,15 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
         nAmount += mint.GetDenominationAsAmount();
     }
 
-    return DoZepgSpend(nAmount, false, true, vMintsSelected, address_str, isPublicSpend);
+    return DoZepgSpend(nAmount, false, true, vMintsSelected, address_str);
 }
 
 
-extern UniValue DoZepgSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend)
+extern UniValue DoZepgSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str)
 {
-    // zerocoin mint / v2 spend is disabled. fMintChange/isPublicSpend should be false here. Double check
-    if (!Params().IsRegTestNet()) {
-        if (fMintChange)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zEPG minting is DISABLED (except for regtest), cannot mint change");
-
-        if (!isPublicSpend)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zEPG old spend only available in regtest for tests purposes");
-    }
+    // zerocoin mint / v2 spend is disabled. fMintChange should be false here. Double check
+    if (!Params().IsRegTestNet() && fMintChange)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zEPG minting is DISABLED (except for regtest), cannot mint change");
 
     int64_t nTimeStart = GetTimeMillis();
     CBitcoinAddress address = CBitcoinAddress(); // Optional sending address. Dummy initialization here.
@@ -3615,7 +3595,7 @@ extern UniValue DoZepgSpend(const CAmount nAmount, bool fMintChange, bool fMinim
     }
 
     EnsureWalletIsUnlocked();
-    fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs, nullptr, isPublicSpend);
+    fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs, nullptr);
 
     if (!fSuccess)
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());
@@ -4275,8 +4255,8 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 4 || params.size() > 7)
         throw std::runtime_error(
-            "spendrawzerocoin \"serialHex\" denom \"randomnessHex\" \"priv key\" ( \"address\" \"mintTxId\" isPublicSpend)\n"
-            "\nCreate and broadcast a TX spending the provided zericoin.\n"
+          "spendrawzerocoin \"serialHex\" denom \"randomnessHex\" \"priv key\" ( \"address\" \"mintTxId\" )\n"
+            "\nCreate and broadcast a TX spending the provided zerocoin.\n"
 
             "\nArguments:\n"
             "1. \"serialHex\"        (string, required) A zerocoin serial number (hex)\n"
@@ -4287,8 +4267,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
             "                        or empty string, spend to change address.\n"
             "6. \"mintTxId\"         (string, optional) txid of the transaction containing the mint. If not"
             "                        specified, or empty string, the blockchain will be scanned (could take a while)"
-            "7. isPublicSpend        (boolean, optional, default=true) create a public zc spend."
-            "                        If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
                 "\"txid\"             (string) The transaction txid in hex\n"
@@ -4296,10 +4274,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
             "\nExamples\n" +
             HelpExampleCli("spendrawzerocoin", "\"f80892e78c30a393ef4ab4d5a9d5a2989de6ebc7b976b241948c7f489ad716a2\" \"a4fd4d7248e6a51f1d877ddd2a4965996154acc6b8de5aa6c83d4775b283b600\" 100 \"xxx\"") +
             HelpExampleRpc("spendrawzerocoin", "\"f80892e78c30a393ef4ab4d5a9d5a2989de6ebc7b976b241948c7f489ad716a2\", \"a4fd4d7248e6a51f1d877ddd2a4965996154acc6b8de5aa6c83d4775b283b600\", 100, \"xxx\""));
-
-    const bool isPublicSpend = (params.size() > 6 ? params[6].get_bool() : true);
-    if (!Params().IsRegTestNet() && !isPublicSpend)
-        throw JSONRPCError(RPC_WALLET_ERROR, "zEPG old spend only available in regtest for tests purposes");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -4370,6 +4344,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
     }
 
     std::vector<CZerocoinMint> vMintsSelected = {mint};
-    return DoZepgSpend(mint.GetDenominationAsAmount(), false, true, vMintsSelected, address_str, isPublicSpend);
+    return DoZepgSpend(mint.GetDenominationAsAmount(), false, true, vMintsSelected, address_str);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2617,6 +2617,12 @@ bool CWallet::CreateCoinStake(
         // Make sure the wallet is unlocked and shutdown hasn't been requested
         if (IsLocked() || ShutdownRequested()) return false;
 
+        // This should never happen
+        if (stakeInput->IsZEPG()) {
+            LogPrintf("%s: ERROR - zPOS is disabled\n", __func__);
+            continue;
+        }
+
         nCredit = 0;
         uint256 hashProofOfStake = 0;
         nAttempts++;
@@ -2645,30 +2651,28 @@ bool CWallet::CreateCoinStake(
             txNew.vout.insert(txNew.vout.end(), vout.begin(), vout.end());
 
             CAmount nMinFee = 0;
-            if (!stakeInput->IsZEPG()) {
-                // Set output amount
-                int outputs = txNew.vout.size() - 1;
-                CAmount nRemaining = nCredit - nMinFee;
-                if (outputs > 1) {
-                    // Split the stake across the outputs
-                    CAmount nShare = nRemaining / outputs;
-                    for (int i = 1; i < outputs; i++) {
-                        // loop through all but the last one.
-                        txNew.vout[i].nValue = nShare;
-                        nRemaining -= nShare;
-                    }
+        // Set output amount
+        int outputs = txNew.vout.size() - 1;
+        CAmount nRemaining = nCredit - nMinFee;
+        if (outputs > 1) {
+            // Split the stake across the outputs
+            CAmount nShare = nRemaining / outputs;
+            for (int i = 1; i < outputs; i++) {
+                // loop through all but the last one.
+                txNew.vout[i].nValue = nShare;
+                nRemaining -= nShare;
                 }
-                // put the remaining on the last output (which all into the first if only one output)
-                txNew.vout[outputs].nValue += nRemaining;
             }
-
+            // put the remaining on the last output (which all into the first if only one output)
+            txNew.vout[outputs].nValue += nRemaining;
+        
             // Limit size
             unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
             if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
                 return error("CreateCoinStake : exceeded coinstake size limit");
 
             //Masternode payment
-        FillBlockPayee(txNew, nMinFee, true, stakeInput->IsZEPG());
+        FillBlockPayee(txNew, nMinFee, true, false);
 
         uint256 hashTxOut = txNew.GetHash();
         CTxIn in;
@@ -2679,14 +2683,6 @@ bool CWallet::CreateCoinStake(
             continue;
         }
         txNew.vin.emplace_back(in);
-
-
-        //Mark mints as spent
-        if (stakeInput->IsZEPG()) {
-            CZEpgStake* z = (CZEpgStake*)stakeInput.get();
-            if (!z->MarkSpent(this, txNew.GetHash()))
-                return error("%s: failed to mark mint as used\n", __func__);
-        }
 
         break;
     }
@@ -3996,40 +3992,6 @@ bool CWallet::CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumul
     return true;
 }
 
-bool CWallet::MintToTxIn(
-        CZerocoinMint mint,
-        const uint256& hashTxOut,
-        CTxIn& newTxIn,
-        CZerocoinSpendReceipt& receipt,
-        libzerocoin::SpendType spendType,
-        CBlockIndex* pindexCheckpoint,
-        bool isPublicSpend)
-{
-    std::map<CBigNum, CZerocoinMint> mapMints;
-    mapMints.insert(std::make_pair(mint.GetValue(), mint));
-    std::vector<CTxIn> vin;
-    if (isPublicSpend) {
-        if (MintsToInputVectorPublicSpend(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
-            newTxIn = vin[0];
-            return true;
-        }
-    } else {
-        if (MintsToInputVector(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
-            newTxIn = vin[0];
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool CWallet::MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
-                         CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
-{
-    // !TODO: remove me (old spends)
-    return false;
-}
-
 bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                                     CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
 {
@@ -4099,7 +4061,7 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
     return true;
 }
 
-bool CWallet::CreateZerocoinSpendTransaction(
+bool CWallet::CreateZCPublicSpendTransaction(
         CAmount nValue,
         CWalletTx& wtxNew,
         CReserveKey& reserveKey,
@@ -4109,8 +4071,7 @@ bool CWallet::CreateZerocoinSpendTransaction(
         bool fMintChange,
         bool fMinimizeChange,
         std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-        CBitcoinAddress* changeAddress,
-        bool isPublicSpend)
+        CBitcoinAddress* changeAddress)
 {
     // Check available funds
     int nStatus = ZEPG_TRX_FUNDS_PROBLEMS;
@@ -4310,15 +4271,9 @@ bool CWallet::CreateZerocoinSpendTransaction(
 
             //add all of the mints to the transaction as inputs
             std::vector<CTxIn> vin;
-            if (isPublicSpend) {
-                if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt,
-                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
-                    return false;
-            } else {
-                if (!MintsToInputVector(mapSelectedMints, hashTxOut, vin, receipt,
-                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
-                    return false;
-            }
+            if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt,
+                                               libzerocoin::SpendType::SPEND, pindexCheckpoint))
+                return false;
             txNew.vin = vin;
 
             // Limit size
@@ -4632,8 +4587,7 @@ bool CWallet::SpendZerocoin(
         bool fMintChange,
         bool fMinimizeChange,
         std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-        CBitcoinAddress* changeAddress,
-        bool isPublicSpend
+        CBitcoinAddress* changeAddress
 )
 {
     // Default: assume something goes wrong. Depending on the problem this gets more specific below
@@ -4646,7 +4600,7 @@ bool CWallet::SpendZerocoin(
 
     CReserveKey reserveKey(this);
     std::vector<CDeterministicMint> vNewMints;
-    if (!CreateZerocoinSpendTransaction(
+    if (!CreateZCPublicSpendTransaction(
             nAmount,
             wtxNew,
             reserveKey,
@@ -4656,8 +4610,7 @@ bool CWallet::SpendZerocoin(
             fMintChange,
             fMinimizeChange,
             addressesTo,
-            changeAddress,
-            isPublicSpend
+            changeAddress
     )) {
         return false;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -99,7 +99,7 @@ enum ZerocoinSpendStatus {
     ZEPG_TRX_FUNDS_PROBLEMS = 6,                    // Everything related to available funds
     ZEPG_TRX_CREATE = 7,                            // Everything related to create the transaction
     ZEPG_TRX_CHANGE = 8,                            // Everything related to transaction change
-    ZEPG_TXMINT_GENERAL = 9,                        // General errors in MintToTxIn
+    ZEPG_TXMINT_GENERAL = 9,                        // General errors in MintsToInputVectorPublicSpend
     ZEPG_INVALID_COIN = 10,                         // Selected mint coin is not valid
     ZEPG_FAILED_ACCUMULATOR_INITIALIZATION = 11,    // Failed to initialize witness
     ZEPG_INVALID_WITNESS = 12,                      // Spend coin transaction did not verify
@@ -209,7 +209,7 @@ public:
     // Zerocoin additions
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, std::vector<CDeterministicMint>& vDMints, CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, const bool isZCSpendChange = false);
 
-    bool CreateZerocoinSpendTransaction(
+    bool CreateZCPublicSpendTransaction(
             CAmount nValue,
             CWalletTx& wtxNew,
             CReserveKey& reserveKey,
@@ -219,13 +219,9 @@ public:
             bool fMintChange,
             bool fMinimizeChange,
             std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-            CBitcoinAddress* changeAddress = nullptr,
-            bool isPublicSpend = true);
+            CBitcoinAddress* changeAddress = nullptr);
 
     bool CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumulator& accumulator, CZerocoinSpendReceipt& receipt);
-    bool MintToTxIn(CZerocoinMint zerocoinSelected, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr, bool isPublicSpend = true);
-    bool MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
-                            CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
     // Public coin spend input creation
     bool MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                                        CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
@@ -241,8 +237,7 @@ public:
             bool fMintChange,
             bool fMinimizeChange,
             std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-            CBitcoinAddress* changeAddress = nullptr,
-            bool isPublicSpend = true
+            CBitcoinAddress* changeAddress = nullptr
     );
 
     std::string ResetMintZerocoin();

--- a/src/zepg/zpos.cpp
+++ b/src/zepg/zpos.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2017-2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "zepg/zpos.h"
+
+
+/*
+ * LEGACY: Kept for IBD in order to verify zerocoin stakes occurred when zPoS was active
+ * Find the first occurrence of a certain accumulator checksum.
+ * Return block index pointer or nullptr if not found
+ */
+
+
+CLegacyZEpgStake::CLegacyZEpgStake(const libzerocoin::CoinSpend& spend)
+{
+    this->nChecksum = spend.getAccumulatorChecksum();
+    this->denom = spend.getDenomination();
+    uint256 nSerial = spend.getCoinSerialNumber().getuint256();
+    this->hashSerial = Hash(nSerial.begin(), nSerial.end());
+}
+
+CBlockIndex* CLegacyZEpgStake::GetIndexFrom()
+{
+    // First look in the legacy database
+    int nHeightChecksum = 0;
+    if (zerocoinDB->ReadAccChecksum(nChecksum, denom, nHeightChecksum)) {
+        return chainActive[nHeightChecksum];
+    }
+
+    // Not found. Scan the chain.
+    CBlockIndex* pindex = chainActive[Params().Zerocoin_StartHeight()];
+    if (!pindex) return nullptr;
+    const int last_block = Params().Zerocoin_Block_Last_Checkpoint();
+    while (pindex && pindex->nHeight <= last_block) {
+        if (ParseAccChecksum(pindex->nAccumulatorCheckpoint, denom) == nChecksum) {
+            // Found. Save to database and return
+            zerocoinDB->WriteAccChecksum(nChecksum, denom, pindex->nHeight);
+            return pindex;
+        }
+        //Skip forward in groups of 10 blocks since checkpoints only change every 10 blocks
+        if (pindex->nHeight % 10 == 0) {
+            pindex = chainActive[pindex->nHeight + 10];
+            continue;
+        }
+        pindex = chainActive.Next(pindex);
+    }
+    return nullptr;
+}
+
+CAmount CLegacyZEpgStake::GetValue() const
+{
+    return denom * COIN;
+}
+
+CDataStream CLegacyZEpgStake::GetUniqueness() const
+{
+    CDataStream ss(SER_GETHASH, 0);
+    ss << hashSerial;
+    return ss;
+}

--- a/src/zepg/zpos.h
+++ b/src/zepg/zpos.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef EPGC_LEGACY_ZPOS_H
+#define EPGC_LEGACY_ZPOS_H
+
+#include "stakeinput.h"
+#include "main.h"
+#include "kernel.h"
+#include "txdb.h"
+
+class CLegacyZEpgStake : public CStakeInput
+{
+private:
+    uint32_t nChecksum;
+    libzerocoin::CoinDenomination denom;
+    uint256 hashSerial;
+
+public:
+    explicit CLegacyZEpgStake(const libzerocoin::CoinSpend& spend);
+    bool IsZEPG() const override { return true; }
+    uint32_t GetChecksum() const { return nChecksum; }
+    CBlockIndex* GetIndexFrom() override;
+    CAmount GetValue() const override;
+    CDataStream GetUniqueness() const override;
+    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override { return false; /* creation disabled */}
+    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
+    bool GetTxFrom(CTransaction& tx) const override { return false; /* not available */ }
+};
+
+#endif //EPGC_LEGACY_ZPOS_H

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -847,12 +847,8 @@ class BitcoinTestFramework():
         prevout = None
         isZPoS = is_zerocoin(block.prevoutStake)
         if isZPoS:
-            _, serialHash, _ = stakeableUtxos[block.prevoutStake]
-            raw_stake = rpc_conn.createrawzerocoinstake(serialHash)
-            stake_tx_signed_raw_hex = raw_stake["hex"]
-            stake_pkey = raw_stake["private-key"]
-            block_sig_key.set_compressed(True)
-            block_sig_key.set_secretbytes(bytes.fromhex(stake_pkey))
+            # !TODO: remove me
+            raise Exception("zPOS tests discontinued")
 
         else:
             coinstakeTx_unsigned = CTransaction()


### PR DESCRIPTION
Zerocoin Cleanup 2: remove CZPivStake class

This removes (now unused) code to produce old zerocoin spends and zPOS stakes.
CZPivStake class is replaced with a CLegacyZPivStake (moved in new files zpiv/zpos.*) used exclusively to validate the chain.
This also refactors CStakeInput class, removing the modifier functions (put back in kernel) and cleans up kernel.* files, removing old code and reorganizing them.


Remove polling based chain height update entirely

Previously we were updating the chain height polling the back-end every 1000ms, acquiring every single time cs_main lock from the main thread. This commit removes this ugly, and not needed, critical section lock entirely using a signal based update.